### PR TITLE
Codex/fwb bootstrap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -205,8 +205,8 @@ data-generating mechanism:
 - `sim_trajectories_brownian_gap()` separates daily latent severity evolution
   from observed state refreshes, which reduces unrealistic day-to-day switching.
   It supports exponential refresh gaps, sampled patient-specific drift starts,
-  and threshold-specific time-effect multipliers for calibrated ordinal
-  occupancy over follow-up.
+  and scalar or threshold-specific time and treatment drift terms for calibrated
+  ordinal occupancy over follow-up.
 - `sim_actt2_brownian()` wraps the Brownian-gap simulator with ACTT-2-inspired
   defaults that preserve broad state occupancy while producing rare state `1`
   to state `3:7` rehospitalization with reduced state `1:2` to `3:7` churn.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,7 @@ The package is built around a small set of stable contracts:
   inference later.
 - Inference engines work by replaying the original SOP request with new
   coefficient draws, posterior draws, score-bootstrap weights, or refit
-  bootstrap samples.
+  bootstrap samples and weights.
 
 This document describes the current design, the main code paths, and how to
 extend the package without breaking those contracts.
@@ -99,8 +99,8 @@ The package is organized by workflow stage rather than by model class.
 | Model fitting helpers | `R/vglm_helpers.R`, `R/vgam_helpers.R`, `R/robcov_vglm.R`, `R/mvn_helpers.R` | Fit package-aware VGAM Markov models, compute effective coefficients, compute robust covariance, mutate coefficients for simulation draws. |
 | SOP API | `R/sops.R`, `R/sops-api.R`, `R/sops-standardize.R` | Public user entrypoints for individual SOPs, standardized/marginal SOPs, and legacy standardization. |
 | SOP engine | `R/sops-engine.R`, `R/sops-backends.R`, `R/sops-fast-path.R`, `R/sops-result-helpers.R` | Validate models, predict transition probabilities, run first- and second-order Markov recursions, reshape arrays to tidy objects. |
-| SOP inference | `R/sops-inference.R`, `R/sops-draws.R`, `R/sops-score-bootstrap.R`, `R/sops-bootstrap-inference.R` | Compute uncertainty intervals from MVN coefficient draws, posterior draws, score bootstrap draws, or refit bootstrap samples. |
-| Bootstrap infrastructure | `R/bootstrap_helpers.R`, `R/bootstrap.R`, `R/bootstrap-tidy.R` | Memory-efficient group bootstrap sampling, just-in-time materialization, model refitting, bootstrap coefficient and SOP summaries. |
+| SOP inference | `R/sops-inference.R`, `R/sops-draws.R`, `R/sops-score-bootstrap.R`, `R/sops-bootstrap-inference.R` | Compute uncertainty intervals from MVN coefficient draws, posterior draws, score bootstrap draws, ordinary refit bootstrap samples, or fractional weighted refits. |
+| Bootstrap infrastructure | `R/bootstrap_helpers.R`, `R/bootstrap.R`, `R/bootstrap-tidy.R` | Memory-efficient group bootstrap sampling, fractional weighted bootstrap weights, just-in-time materialization, model refitting, bootstrap coefficient and SOP summaries. |
 | Endpoint summaries | `R/endpoint-summaries.R`, `R/endpoint-tte.R`, `R/competing-risks.R`, `R/sops-time-in-state.R`, `R/sops-interpolate.R` | Convert trajectories or SOPs to days-at-home, time-to-event, competing-risk, real-time interpolation, and time-in-state summaries. |
 | Operating characteristics | `R/power.R` | Sample from Arrow superpopulations, run iteration-level analyses, summarize power, type I error, bias, coverage, and Monte Carlo error. |
 | Visualization | `R/viz.R` | Plot empirical or model-derived SOPs, bootstrap SOP bands, and operating-characteristic summaries. |
@@ -280,10 +280,12 @@ flowchart TD
   VCOV --> DRAWS["Draw beta from multivariate normal"]
   KIND -- "simulation + score_bootstrap" --> SCORE["Generate one-step score-bootstrap beta draws and optional weights"]
   SCORE --> DRAWS
-  KIND -- "bootstrap" --> RESAMPLE["Group-bootstrap IDs, materialize samples, refit models"]
+  KIND -- "bootstrap + standard" --> RESAMPLE["Group-bootstrap IDs, materialize samples, refit models"]
+  KIND -- "bootstrap + fwb" --> FWB["Draw mean-one exponential patient weights, refit weighted models"]
   KIND -- "posterior blrm" --> POST["Use stored posterior predictions"]
   DRAWS --> REPLAY["Replay SOP prediction for each draw"]
   RESAMPLE --> REPLAY
+  FWB --> REPLAY
   POST --> CI["Summarize draw distribution"]
   REPLAY --> CI
   CI --> OUT["Original SOP object + intervals + optional stored draws"]
@@ -297,8 +299,12 @@ The inference methods are intentionally separate:
   from `stats::vcov()`, `rms::robcov()`, or `robcov_vglm()`.
 - Score bootstrap uses row-level model scores and cluster multipliers to make
   one-step coefficient draws without full refits.
-- Refit bootstrap resamples patients by ID, materializes each bootstrap sample,
-  refits the model, and recomputes `avg_sops()`.
+- Standard refit bootstrap resamples patients by ID, materializes each bootstrap
+  sample, refits the model, and recomputes `avg_sops()`.
+- Fractional weighted bootstrap draws one exponential weight per patient ID,
+  normalizes those weights to mean 1 for model fitting, refits the model with
+  row-expanded weights, and uses the same patient weights for marginal SOP
+  averaging.
 
 For first-order frequentist `orm` and `vglm` models, simulation inference can use
 the optimized fast path. Second-order Markov models fall back to replaying the
@@ -456,11 +462,15 @@ orchestration.
 ```mermaid
 flowchart TD
   DATA["Original longitudinal data"] --> IDS["fast_group_bootstrap()"]
+  DATA --> FWB_IDS["generate_fwb_bootstrap_weights()"]
   IDS --> LOOKUP["Small ID lookup tables"]
   LOOKUP --> APPLY["apply_to_bootstrap()"]
   APPLY --> MATERIALIZE["materialize_bootstrap_sample()"]
+  FWB_IDS --> FWB_APPLY["apply_to_fwb_bootstrap()"]
+  FWB_APPLY --> FWB_MATERIALIZE["materialize_fwb_bootstrap_sample()"]
   MATERIALIZE --> RELEVEL["relevel_factors_consecutive()"]
-  RELEVEL --> REFIT["stats::update(model, data = boot_data)"]
+  FWB_MATERIALIZE --> RELEVEL
+  RELEVEL --> REFIT["stats::update(model, data = boot_data, weights = optional)"]
   REFIT --> ANALYSIS{"Analysis target"}
   ANALYSIS -- "coefficients" --> COEF["bootstrap_model_coefs()"]
   ANALYSIS -- "standardized SOPs" --> SOP["bootstrap_standardized_sops()"]
@@ -471,18 +481,28 @@ The key design choice is just-in-time materialization. `fast_group_bootstrap()`
 stores only sampled IDs and unique bootstrap IDs. Workers receive a lookup
 table, join it to the original data, refit, and return only the requested
 result. This avoids storing all bootstrap data sets at once and keeps repeated
-patient samples identifiable through `new_id`.
+patient samples identifiable through `new_id`. The fractional weighted
+bootstrap path follows the same just-in-time style but stores patient-level
+exponential weights instead of duplicated ID lookups.
 
 `bootstrap_analysis_wrapper()` centralizes the fragile parts of refitting:
 
 - Relevel missing factor states to consecutive integers.
 - Update `rms::datadist()` for `orm` fits when needed.
 - Optionally use original VGAM coefficients as starting values.
+- Optionally multiply recoverable original model weights by fractional
+  bootstrap weights and pass them into `stats::update()`.
 - Return the fitted model, releveled data, updated state support, and missing
   states.
 
 SOP bootstrap inference currently targets `markov_avg_sops`, because marginal
 SOPs have a clear population-level resampling interpretation.
+
+For `method = "bootstrap", engine = "fwb"`, weights are drawn at the patient ID
+level, normalized to mean 1 over patients for model fitting, expanded to rows,
+and then separately normalized to sum 1 by `marginalize_sops_array()` when
+averaging counterfactual SOPs. This mirrors the default exponential weighting
+behavior of the external `fwb` package without adding it as a dependency.
 
 ## Score Bootstrap Design
 
@@ -728,10 +748,10 @@ interfaces or examples change.
 | `R/sops-fast-path.R` | `markov_msm_build()`, `markov_msm_run()`, `lp_to_probs()`, `compute_Gamma()` | Optimized repeated prediction for eligible first-order models. |
 | `R/sops-result-helpers.R` | `set_sops_attrs()`, `restore_sops_attrs()`, `create_counterfactual_data()`, `marginalize_sops_array()`, `array_to_df_individual()` | Tidy SOP object construction and attribute preservation. |
 | `R/sops-inference.R` | `inferences()`, `inferences_simulation()` | Main inference dispatcher and coefficient-draw replay. |
-| `R/sops-bootstrap-inference.R` | `inferences_bootstrap()` | Refit-bootstrap inference for marginal SOPs. |
+| `R/sops-bootstrap-inference.R` | `inferences_bootstrap()` | Standard and fractional weighted refit-bootstrap inference for marginal SOPs. |
 | `R/sops-score-bootstrap.R` | `generate_score_bootstrap_draws()`, `score_bootstrap_components()`, `compute_scores_orm()` | One-step score-bootstrap engine. |
 | `R/sops-draws.R` | `compute_ci_from_draws()`, `get_draws()` | Interval summaries and draw extraction. |
-| `R/bootstrap_helpers.R` | `fast_group_bootstrap()`, `materialize_bootstrap_sample()`, `apply_to_bootstrap()`, `bootstrap_analysis_wrapper()` | Memory-efficient group bootstrap utilities. |
+| `R/bootstrap_helpers.R` | `fast_group_bootstrap()`, `generate_fwb_bootstrap_weights()`, `materialize_bootstrap_sample()`, `materialize_fwb_bootstrap_sample()`, `apply_to_bootstrap()`, `apply_to_fwb_bootstrap()`, `bootstrap_analysis_wrapper()` | Memory-efficient standard and fractional weighted bootstrap utilities. |
 | `R/bootstrap.R` | `bootstrap_model_coefs()`, `bootstrap_standardized_sops()` | Exported bootstrap summaries. |
 | `R/bootstrap-tidy.R` | `tidy_bootstrap_coefs()` | Quantile summaries for bootstrap coefficients. |
 | `R/sops-interpolate.R` | `interpolate_sops()` and helpers | Visit-to-real-time SOP interpolation and draw-aware interval recomputation. |
@@ -759,4 +779,5 @@ interfaces or examples change.
 | Fast path | Matrix-based SOP replay path for repeated coefficient draws in eligible first-order models. |
 | Score bootstrap | Approximate bootstrap using score contributions and multiplier weights instead of full refits. |
 | Refit bootstrap | Bootstrap that resamples IDs, refits the model, and recomputes SOPs. |
+| Fractional weighted bootstrap | Bootstrap that gives each patient a positive exponential weight, refits the model with row-expanded weights, and marginalizes SOPs with the same patient weights. |
 | Real-time interpolation | Mapping visit-index SOPs to elapsed time and interpolating probabilities for AUC/time-in-state summaries. |

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@
   SOP prediction, MVN inference with full `rms::robcov()` covariance matrices,
   refit bootstrap inference, and score-bootstrap inference via
   `inferences(..., engine = "score_bootstrap", cluster = <id>)`.
+- `inferences()` now supports fractional weighted bootstrap refits via
+  `method = "bootstrap", engine = "fwb"`, using mean-one exponential
+  patient-level weights for fitting and weighted SOP marginalization.
 - `interpolate_sops()` maps visit-scale SOP output to real elapsed time with
   optional empirical baseline anchoring, and `time_in_state()` can now compute
   trapezoidal real-time AUC while `soprob_markov()`, `sops()`, and `avg_sops()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 - `sim_actt2_brownian()` now uses calibrated Brownian-gap defaults that reduce
   state `1:2` to state `3:7` rehospitalization-like churn, while
   `sim_trajectories_brownian_gap()` supports sampled patient-specific drift
-  starts and threshold-specific time-effect multipliers.
+  starts and scalar or threshold-specific time and treatment effects.
 - `blrm` SOP prediction now caches fitted random-effect draws once per call and
   vectorizes posterior recursion within chunks; state-wise median summaries are
   documented as not necessarily summing to one across states, while draw-level

--- a/R/bootstrap_helpers.R
+++ b/R/bootstrap_helpers.R
@@ -155,6 +155,87 @@ materialize_bootstrap_sample <- function(boot_ids, data, id_var) {
   return(boot_sample)
 }
 
+generate_fwb_bootstrap_weights <- function(
+  data,
+  id_var = "id",
+  n_boot,
+  weight_dist = "exponential"
+) {
+  if (!id_var %in% names(data)) {
+    stop("id_var '", id_var, "' not found in data")
+  }
+
+  weight_dist <- match.arg(weight_dist, choices = "exponential")
+  cluster_ids <- unique(data[[id_var]])
+  n_clusters <- length(cluster_ids)
+  fwb_samples <- vector("list", n_boot)
+
+  for (i in seq_len(n_boot)) {
+    raw_weights <- stats::rexp(n_clusters, rate = 1)
+    weight_mean <- mean(raw_weights)
+    if (!is.finite(weight_mean) || weight_mean <= 0) {
+      stop("Invalid fractional bootstrap weights generated.")
+    }
+
+    fwb_samples[[i]] <- data.frame(
+      original_id = cluster_ids,
+      fwb_weight = raw_weights / weight_mean,
+      boot_id = i
+    )
+  }
+
+  fwb_samples
+}
+
+materialize_fwb_bootstrap_sample <- function(fwb_weights, data, id_var) {
+  if (!all(c("original_id", "fwb_weight", "boot_id") %in% names(fwb_weights))) {
+    stop(
+      "`fwb_weights` must contain original_id, fwb_weight, and boot_id columns."
+    )
+  }
+
+  idx <- match(
+    as.character(data[[id_var]]),
+    as.character(fwb_weights$original_id)
+  )
+  if (anyNA(idx)) {
+    missing_ids <- unique(as.character(data[[id_var]])[is.na(idx)])
+    stop(
+      "Some data IDs were not found in the fractional bootstrap weights: ",
+      paste(utils::head(missing_ids, 5), collapse = ", "),
+      if (length(missing_ids) > 5) " ..." else "",
+      "."
+    )
+  }
+
+  boot_data <- data
+  boot_data$fwb_weight <- fwb_weights$fwb_weight[idx]
+  boot_data$boot_id <- fwb_weights$boot_id[idx]
+  boot_data
+}
+
+fwb_baseline_weights <- function(fwb_weights, baseline_data, id_var) {
+  if (!id_var %in% names(baseline_data)) {
+    stop("ID variable '", id_var, "' not found in baseline data.")
+  }
+
+  idx <- match(
+    as.character(baseline_data[[id_var]]),
+    as.character(fwb_weights$original_id)
+  )
+  if (anyNA(idx)) {
+    missing_ids <- unique(as.character(baseline_data[[id_var]])[is.na(idx)])
+    stop(
+      "Some baseline IDs were not found in the fractional bootstrap weights: ",
+      paste(utils::head(missing_ids, 5), collapse = ", "),
+      if (length(missing_ids) > 5) " ..." else "",
+      "."
+    )
+  }
+
+  fwb_weights$fwb_weight[idx]
+}
+
 
 #' Apply Function to Bootstrap Samples with Parallelization
 #'
@@ -289,6 +370,43 @@ apply_to_bootstrap <- function(
   return(results)
 }
 
+apply_to_fwb_bootstrap <- function(
+  fwb_samples,
+  analysis_fn,
+  data,
+  id_var,
+  workers = NULL,
+  packages = c("rms", "VGAM", "Hmisc", "stats"),
+  globals = character(0)
+) {
+  use_parallel <- !is.null(workers) && workers > 1
+  materialize_fwb <- materialize_fwb_bootstrap_sample
+
+  wrapper_fn <- function(fwb_weights) {
+    boot_data <- materialize_fwb(fwb_weights, data, id_var)
+    analysis_fn(boot_data, fwb_weights)
+  }
+
+  if (use_parallel) {
+    old_plan <- plan()
+    on.exit(plan(old_plan), add = TRUE)
+    plan(callr, workers = workers)
+
+    results <- furrr::future_map(
+      fwb_samples,
+      wrapper_fn,
+      .options = furrr::furrr_options(
+        packages = c(packages),
+        globals = c(globals, "data", "id_var", "analysis_fn", "materialize_fwb")
+      )
+    )
+  } else {
+    results <- lapply(fwb_samples, wrapper_fn)
+  }
+
+  results
+}
+
 
 #' Bootstrap Analysis Wrapper
 #'
@@ -306,6 +424,7 @@ apply_to_bootstrap <- function(
 #'   (only needed for rms::orm models)
 #' @param use_coefstart Logical indicating whether to use starting coefficients
 #'   from the original model when refitting (only for vglm models).
+#' @param fit_weights Optional non-negative row weights for the bootstrap fit.
 #'
 #' @return A list with components:
 #'   \itemize{
@@ -348,8 +467,25 @@ bootstrap_analysis_wrapper <- function(
   ylevels = NULL,
   absorb = NULL,
   update_datadist = TRUE,
-  use_coefstart = FALSE
+  use_coefstart = FALSE,
+  fit_weights = NULL
 ) {
+  fit_model <- bootstrap_refit_model(model)
+
+  if (!is.null(fit_weights)) {
+    if (
+      !is.numeric(fit_weights) ||
+        length(fit_weights) != nrow(boot_data) ||
+        any(!is.finite(fit_weights)) ||
+        any(fit_weights < 0)
+    ) {
+      stop("`fit_weights` must be non-negative finite row weights.")
+    }
+
+    original_weights <- bootstrap_original_fit_weights(fit_model, boot_data)
+    boot_data$.markov_misc_fit_weight <- original_weights * fit_weights
+  }
+
   # Relevel factors to handle missing states
   releveled <- relevel_factors_consecutive(
     data = boot_data,
@@ -365,7 +501,7 @@ bootstrap_analysis_wrapper <- function(
   missing_states <- releveled$missing_levels
 
   # Update datadist if needed (only for orm models)
-  if (update_datadist && inherits(model, "orm")) {
+  if (update_datadist && inherits(fit_model, "orm")) {
     dd_env <- globalenv()
     old_datadist <- getOption("datadist")
     old_dd_exists <- exists("dd", envir = dd_env, inherits = FALSE)
@@ -382,7 +518,7 @@ bootstrap_analysis_wrapper <- function(
       add = TRUE
     )
 
-    dd <- rms::datadist(boot_data)
+    dd <- rms::datadist(bootstrap_datadist_data(boot_data))
     assign("dd", dd, envir = dd_env)
     options(datadist = "dd")
   }
@@ -392,25 +528,36 @@ bootstrap_analysis_wrapper <- function(
     {
       # Attempt with coefstart if conditions met
       if (
-        use_coefstart && inherits(model, "vglm") && length(missing_states) == 0
+        use_coefstart &&
+          inherits(fit_model, "vglm") &&
+          length(missing_states) == 0
       ) {
         tryCatch(
           {
-            stats::update(
-              model,
-              data = boot_data,
-              coefstart = stats::coef(model)
+            update_bootstrap_model(
+              fit_model,
+              boot_data,
+              fit_weights = fit_weights,
+              coefstart = stats::coef(fit_model)
             )
           },
           error = function(e) {
             # If coefstart fails (e.g. non-conformable due to dropped predictor levels),
             # fall back to standard update
-            stats::update(model, data = boot_data)
+            update_bootstrap_model(
+              fit_model,
+              boot_data,
+              fit_weights = fit_weights
+            )
           }
         )
       } else {
         # Standard update without coefstart
-        stats::update(model, data = boot_data)
+        update_bootstrap_model(
+          fit_model,
+          boot_data,
+          fit_weights = fit_weights
+        )
       }
     },
     error = function(e) {
@@ -426,4 +573,196 @@ bootstrap_analysis_wrapper <- function(
     absorb = boot_absorb,
     missing_states = missing_states
   ))
+}
+
+bootstrap_datadist_data <- function(data) {
+  metadata_cols <- c(
+    "boot_id",
+    "new_id",
+    "fwb_weight",
+    ".markov_misc_fit_weight"
+  )
+  data[, setdiff(names(data), metadata_cols), drop = FALSE]
+}
+
+bootstrap_refit_model <- function(model) {
+  if (inherits(model, "robcov_vglm")) {
+    if (is.null(model$vglm_fit)) {
+      stop(
+        "The supplied robcov_vglm object does not contain the original vglm fit."
+      )
+    }
+    return(model$vglm_fit)
+  }
+
+  model
+}
+
+bootstrap_original_fit_weights <- function(model, data) {
+  stored_weights <- bootstrap_stored_fit_weights(model, data)
+  if (!is.null(stored_weights)) {
+    return(stored_weights)
+  }
+
+  model_call <- if (inherits(model, "vglm")) {
+    tryCatch(methods::slot(model, "call"), error = function(e) NULL)
+  } else {
+    model$call
+  }
+
+  if (is.null(model_call) || is.null(model_call$weights)) {
+    return(rep(1, nrow(data)))
+  }
+
+  weights <- tryCatch(
+    eval(model_call$weights, data, parent.frame()),
+    error = function(e) NULL
+  )
+
+  if (is.null(weights)) {
+    warning(
+      "Could not recover original model weights; using fractional ",
+      "bootstrap weights only.",
+      call. = FALSE
+    )
+    return(rep(1, nrow(data)))
+  }
+
+  if (
+    length(weights) != nrow(data) ||
+      any(!is.finite(weights)) ||
+      any(weights < 0)
+  ) {
+    stop("Original model weights must be non-negative finite row weights.")
+  }
+
+  as.numeric(weights)
+}
+
+bootstrap_stored_fit_weights <- function(model, data) {
+  candidates <- list(
+    tryCatch(
+      stats::model.weights(stats::model.frame(model)),
+      error = function(e) NULL
+    ),
+    bootstrap_model_component(model, "prior.weights"),
+    bootstrap_model_component(model, "weights"),
+    if (inherits(model, "vglm")) {
+      tryCatch(methods::slot(model, "prior.weights"), error = function(e) NULL)
+    } else {
+      NULL
+    }
+  )
+
+  for (weights in candidates) {
+    weights <- bootstrap_as_row_weights(weights, nrow(data))
+    if (!is.null(weights)) {
+      return(weights)
+    }
+  }
+
+  NULL
+}
+
+bootstrap_model_component <- function(model, name) {
+  if (methods::is(model, "S4")) {
+    return(NULL)
+  }
+
+  tryCatch(model[[name]], error = function(e) NULL)
+}
+
+bootstrap_as_row_weights <- function(weights, n_rows) {
+  if (is.null(weights)) {
+    return(NULL)
+  }
+
+  if (is.matrix(weights) || is.data.frame(weights)) {
+    if (nrow(weights) != n_rows) {
+      return(NULL)
+    }
+    if (ncol(weights) == 1) {
+      weights <- weights[, 1]
+    } else if (all(weights == weights[, 1])) {
+      weights <- weights[, 1]
+    } else {
+      return(NULL)
+    }
+  }
+
+  if (!is.numeric(weights) || length(weights) != n_rows) {
+    return(NULL)
+  }
+  if (any(!is.finite(weights)) || any(weights < 0)) {
+    stop("Original model weights must be non-negative finite row weights.")
+  }
+
+  as.numeric(weights)
+}
+
+update_bootstrap_model <- function(
+  model,
+  boot_data,
+  fit_weights = NULL,
+  coefstart = NULL
+) {
+  has_fit_weights <- !is.null(fit_weights)
+
+  if (has_fit_weights && !is.null(coefstart)) {
+    return(suppress_orm_bootstrap_weight_warning(
+      model,
+      stats::update(
+        model,
+        data = boot_data,
+        weights = .markov_misc_fit_weight,
+        coefstart = coefstart
+      )
+    ))
+  }
+  if (has_fit_weights) {
+    return(suppress_orm_bootstrap_weight_warning(
+      model,
+      stats::update(
+        model,
+        data = boot_data,
+        weights = .markov_misc_fit_weight
+      )
+    ))
+  }
+  if (!is.null(coefstart)) {
+    return(suppress_orm_bootstrap_weight_warning(
+      model,
+      stats::update(
+        model,
+        data = boot_data,
+        coefstart = coefstart
+      )
+    ))
+  }
+
+  suppress_orm_bootstrap_weight_warning(
+    model,
+    stats::update(model, data = boot_data)
+  )
+}
+
+suppress_orm_bootstrap_weight_warning <- function(model, expr) {
+  if (!inherits(model, "orm")) {
+    return(expr)
+  }
+
+  withCallingHandlers(
+    expr,
+    warning = function(w) {
+      if (
+        grepl(
+          "currently weights are ignored in model validation and bootstrapping orm fits",
+          conditionMessage(w),
+          fixed = TRUE
+        )
+      ) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
 }

--- a/R/globals.R
+++ b/R/globals.R
@@ -78,6 +78,7 @@ utils::globalVariables(c(
   "raw_stop",
   # Added for inferences_bootstrap
   "n_rows",
+  ".markov_misc_fit_weight",
   # Added for tidy_bootstrap_coefs
   "n_iter"
 ))

--- a/R/simulate-brownian-gap.R
+++ b/R/simulate-brownian-gap.R
@@ -8,16 +8,23 @@
 #' @param n_patients Integer. Number of patients to simulate (default: 1000).
 #' @param follow_up_time Integer. Number of days to simulate per patient (default: 60).
 #' @param n_states Integer. Number of ordered states/categories (default: 6).
-#' @param mu_drift Numeric. Baseline (constant) drift per day for control group
-#'   (default: -0.26). Negative values indicate improvement.
+#' @param mu_drift Numeric scalar or vector of length `n_states - 1`. Baseline
+#'   threshold-specific drift per day for the control group (default: -0.26).
+#'   Negative values indicate improvement. Vector element `j` affects threshold
+#'   `j`, the boundary between states `j` and `j + 1`.
 #' @param mu_drift_sd Numeric. Standard deviation of a patient-specific random
 #'   drift component added to `mu_drift` (default: 0). This induces persistent
 #'   heterogeneity in individual improvement or worsening rates over follow-up.
-#' @param mu_quad Numeric. Quadratic coefficient for time-varying drift
-#'   (default: 0.006).
-#' @param mu_quad2 Numeric. Second-order quadratic coefficient for drift (default: 0).
-#' @param mu_treatment_effect Numeric. Additional constant drift for treatment group
-#'   (default: -0.04). Negative values indicate faster improvement with treatment.
+#' @param mu_quad Numeric scalar or vector of length `n_states - 1`. Quadratic
+#'   coefficient for threshold-specific time-varying drift (default: 0.006).
+#' @param mu_quad2 Numeric scalar or vector of length `n_states - 1`.
+#'   Second-order quadratic coefficient for threshold-specific drift (default:
+#'   0).
+#' @param mu_treatment_effect Numeric scalar or vector of length `n_states - 1`.
+#'   Additional threshold-specific drift for the treatment group (default:
+#'   -0.04). Negative values indicate faster improvement with treatment. To
+#'   target a single adjacent-state boundary, set only that vector element to a
+#'   nonzero value.
 #' @param sigma_rw Numeric. Random walk innovation standard deviation per day
 #'   (default: 0.12).
 #' @param x0_sd Numeric. Standard deviation for baseline latent severity
@@ -44,11 +51,6 @@
 #' @param refresh_rate Numeric scalar. Exponential rate per day for the next
 #'   non-absorbing state refresh (default: 0.048). Lower values create longer
 #'   dwell times between observed state updates.
-#' @param threshold_time_effect_factors Numeric vector of length K-1 or `NULL`.
-#'   Multipliers for how strongly the common deterministic latent drift affects
-#'   each threshold over time (default: `NULL`, equivalent to all 1s). Values
-#'   below 1 attenuate the time effect for a threshold; values above 1 amplify
-#'   it. The induced day-specific thresholds must remain strictly increasing.
 #' @param seed Integer. Random seed for reproducibility (default: NULL).
 #'
 #' @return A data frame (tibble) with columns:
@@ -56,19 +58,22 @@
 #'   - time: time/day (1 to follow_up_time)
 #'   - tx: treatment assignment (0 = control, 1 = treatment)
 #'   - y: observed ordinal state at time
-#'   - x: latent continuous severity
+#'   - x: reference latent continuous severity
 #'
 #' @details
 #' This function modifies the daily Brownian simulator by separating latent
 #' evolution from observed-state refresh:
 #' 1. Each patient has an unobserved continuous "severity" X(t) that evolves
 #'    daily as a Gaussian random walk with drift.
-#' 2. A patient-specific waiting time to the next refresh is drawn from an
+#' 2. When drift parameters are threshold-specific vectors, `x` follows a
+#'    reference latent drift while observed-state probabilities are generated
+#'    from threshold-specific cutpoint trajectories.
+#' 3. A patient-specific waiting time to the next refresh is drawn from an
 #'    exponential distribution with rate `refresh_rate`.
-#' 3. Between refresh dates, non-absorbing observed states are carried forward.
-#' 4. On refresh dates, the observed state is resampled from the latent-variable
+#' 4. Between refresh dates, non-absorbing observed states are carried forward.
+#' 5. On refresh dates, the observed state is resampled from the latent-variable
 #'    category probabilities excluding the absorbing state.
-#' 5. Entry into the absorbing state can occur on any day according to the
+#' 6. Entry into the absorbing state can occur on any day according to the
 #'    daily latent death probability; once entered, it is carried forward.
 #'
 #' @examples
@@ -81,6 +86,13 @@
 #' traj_gap_low_switch <- sim_trajectories_brownian_gap(
 #'   n_patients = 1000,
 #'   refresh_rate = 0.02,
+#'   seed = 12345
+#' )
+#'
+#' # Treatment effect only at the state 5/6 boundary
+#' traj_gap_targeted <- sim_trajectories_brownian_gap(
+#'   n_patients = 1000,
+#'   mu_treatment_effect = c(0, 0, 0, 0, -0.04),
 #'   seed = 12345
 #' )
 #' }
@@ -107,7 +119,6 @@ sim_trajectories_brownian_gap <- function(
   drift_start = 0,
   latent_dist = c("logistic", "normal"),
   refresh_rate = 0.048,
-  threshold_time_effect_factors = NULL,
   seed = NULL
 ) {
   if (n_patients < 1 || !is.numeric(n_patients)) {
@@ -139,20 +150,33 @@ sim_trajectories_brownian_gap <- function(
     stop("thresholds must be a strictly increasing numeric vector")
   }
 
-  if (is.null(threshold_time_effect_factors)) {
-    threshold_time_effect_factors <- rep(1, n_states - 1)
+  normalize_threshold_effect <- function(x, name) {
+    if (
+      !is.numeric(x) ||
+        !(length(x) %in% c(1, n_states - 1)) ||
+        any(!is.finite(x))
+    ) {
+      stop(
+        name,
+        " must be a finite numeric scalar or vector with length n_states - 1"
+      )
+    }
+
+    rep(x, length.out = n_states - 1)
   }
 
-  if (
-    !is.numeric(threshold_time_effect_factors) ||
-      length(threshold_time_effect_factors) != (n_states - 1) ||
-      any(!is.finite(threshold_time_effect_factors))
-  ) {
-    stop(
-      "threshold_time_effect_factors must be NULL or a finite numeric vector ",
-      "with length n_states - 1"
-    )
-  }
+  mu_drift_threshold <- normalize_threshold_effect(mu_drift, "mu_drift")
+  mu_quad_threshold <- normalize_threshold_effect(mu_quad, "mu_quad")
+  mu_quad2_threshold <- normalize_threshold_effect(mu_quad2, "mu_quad2")
+  mu_treatment_threshold <- normalize_threshold_effect(
+    mu_treatment_effect,
+    "mu_treatment_effect"
+  )
+
+  mu_drift_reference <- mean(mu_drift_threshold)
+  mu_quad_reference <- mean(mu_quad_threshold)
+  mu_quad2_reference <- mean(mu_quad2_threshold)
+  mu_treatment_reference <- mean(mu_treatment_threshold)
 
   if (treatment_prob < 0 || treatment_prob > 1) {
     stop("treatment_prob must be between 0 and 1")
@@ -262,32 +286,49 @@ sim_trajectories_brownian_gap <- function(
       return(0)
     }
 
-    mu_base <- mu_drift +
+    mu_base <- mu_drift_reference +
       drift_i +
-      mu_quad * elapsed_day +
-      mu_quad2 * elapsed_day^2
-    mu_i <- mu_base + tx * mu_treatment_effect
+      mu_quad_reference * elapsed_day +
+      mu_quad2_reference * elapsed_day^2
+    mu_i <- mu_base + tx * mu_treatment_reference
 
     mu_i * calc_piecewise_factor(elapsed_day)
   }
 
   threshold_matrix_cache <- new.env(parent = emptyenv())
-  make_threshold_matrix <- function(drift_start_i) {
-    cache_key <- as.character(drift_start_i)
+  make_threshold_matrix <- function(drift_start_i, tx) {
+    cache_key <- paste(drift_start_i, tx, sep = ":")
     if (exists(cache_key, envir = threshold_matrix_cache, inherits = FALSE)) {
       return(get(cache_key, envir = threshold_matrix_cache, inherits = FALSE))
     }
 
-    common_drift <- numeric(follow_up_time + 1)
+    reference_drift <- numeric(follow_up_time + 1)
+    threshold_drift <- matrix(
+      0,
+      nrow = follow_up_time + 1,
+      ncol = n_states - 1
+    )
     for (t in 2:(follow_up_time + 1)) {
       day <- t - 1
       elapsed_day <- day - drift_start_i
       if (elapsed_day < 0) {
-        common_drift[t] <- common_drift[t - 1]
+        reference_drift[t] <- reference_drift[t - 1]
+        threshold_drift[t, ] <- threshold_drift[t - 1, ]
       } else {
-        common_drift[t] <- common_drift[t - 1] +
-          (mu_drift + mu_quad * elapsed_day + mu_quad2 * elapsed_day^2) *
-            calc_piecewise_factor(elapsed_day)
+        piecewise_factor <- calc_piecewise_factor(elapsed_day)
+        reference_step <- (mu_drift_reference +
+          mu_quad_reference * elapsed_day +
+          mu_quad2_reference * elapsed_day^2 +
+          tx * mu_treatment_reference) *
+          piecewise_factor
+        threshold_step <- (mu_drift_threshold +
+          mu_quad_threshold * elapsed_day +
+          mu_quad2_threshold * elapsed_day^2 +
+          tx * mu_treatment_threshold) *
+          piecewise_factor
+
+        reference_drift[t] <- reference_drift[t - 1] + reference_step
+        threshold_drift[t, ] <- threshold_drift[t - 1, ] + threshold_step
       }
     }
 
@@ -297,12 +338,13 @@ sim_trajectories_brownian_gap <- function(
       ncol = n_states - 1,
       byrow = TRUE
     ) +
-      outer(common_drift, 1 - threshold_time_effect_factors)
+      reference_drift -
+      threshold_drift
 
     if (!all(apply(threshold_matrix, 1, function(x) all(diff(x) > 0)))) {
       stop(
-        "threshold_time_effect_factors induce crossing thresholds; ",
-        "use factors that keep thresholds strictly increasing over follow-up"
+        "threshold-specific drift terms induce crossing thresholds; ",
+        "use effects that keep thresholds strictly increasing over follow-up"
       )
     }
 
@@ -311,7 +353,7 @@ sim_trajectories_brownian_gap <- function(
   }
 
   for (i in seq_len(n_patients)) {
-    threshold_matrix_i <- make_threshold_matrix(drift_start[i])
+    threshold_matrix_i <- make_threshold_matrix(drift_start[i], treatment[i])
     X[i, 1] <- stats::rnorm(1, 0, x0_sd)
 
     # sample initial state occupancy probabilities
@@ -396,6 +438,8 @@ sim_trajectories_brownian_gap <- function(
 #' occupancy while reducing rehospitalization-like movement from recovered
 #' states 1/2 into states 3:7. The defaults are null-aligned, so there is no
 #' built-in treatment difference unless `mu_treatment_effect` is changed.
+#' `mu_treatment_effect` may be a scalar, which affects every threshold equally,
+#' or a vector with one value per threshold.
 #'
 #' This is intended as a convenient starting point for simulation studies, not
 #' as an exact recreation of the original trial.
@@ -403,8 +447,10 @@ sim_trajectories_brownian_gap <- function(
 #' @param n_patients Integer. Number of patients to simulate (default: 1000).
 #' @param treatment_prob Numeric. Probability of assignment to treatment group
 #'   (default: 0.5).
-#' @param mu_treatment_effect Numeric. Additional constant drift for treatment
-#'   group (default: 0, meaning no arm difference).
+#' @param mu_treatment_effect Numeric scalar or vector of length 7. Additional
+#'   threshold-specific drift for the treatment group (default: 0, meaning no
+#'   arm difference). Vector element `j` affects the boundary between states `j`
+#'   and `j + 1`.
 #' @param seed Integer. Random seed for reproducibility (default: NULL).
 #' @param ... Additional arguments passed to
 #'   [sim_trajectories_brownian_gap()]. These can be used to override any of the
@@ -422,6 +468,12 @@ sim_trajectories_brownian_gap <- function(
 #'   mu_treatment_effect = -0.03,
 #'   seed = 123
 #' )
+#'
+#' actt2_state5_to_6 <- sim_actt2_brownian(
+#'   n_patients = 1000,
+#'   mu_treatment_effect = c(0, 0, 0, 0, 0.03, 0, 0),
+#'   seed = 123
+#' )
 #' }
 #'
 #' @export
@@ -437,10 +489,18 @@ sim_actt2_brownian <- function(
       n_patients = n_patients,
       follow_up_time = 28,
       n_states = 8,
-      mu_drift = -2.2,
+      mu_drift = c(-0.99, -1.1, -1.1, -1.1, -1.1, -1.078, -1.1),
       mu_drift_sd = 1, #0.28,
-      mu_quad = 0,
-      mu_quad2 = -0.001,
+      mu_quad = c(0, 0, 0, 0, 0, 0, 0),
+      mu_quad2 = c(
+        -0.00045,
+        -0.0005,
+        -0.0005,
+        -0.0005,
+        -0.0005,
+        -0.00049,
+        -0.0005
+      ),
       mu_treatment_effect = mu_treatment_effect,
       sigma_rw = 0.055,
       x0_sd = 0.35,
@@ -452,7 +512,6 @@ sim_actt2_brownian <- function(
       drift_start = function(n) rpois(n, 3.2),
       latent_dist = "logistic",
       refresh_rate = 0.32,
-      threshold_time_effect_factors = c(0.45, 0.5, 0.5, 0.5, 0.5, 0.49, 0.5),
       seed = seed
     ),
     list(...)

--- a/R/sops-bootstrap-inference.R
+++ b/R/sops-bootstrap-inference.R
@@ -11,6 +11,7 @@
 #' bootstrap sample.
 #'
 #' @param object A `markov_avg_sops` object.
+#' @param engine Bootstrap engine, `"standard"` or `"fwb"`.
 #' @param n_boot Number of bootstrap iterations.
 #' @param workers Number of parallel workers. If NULL or 1, uses sequential
 #'   processing. If > 1, uses parallel processing.
@@ -24,6 +25,7 @@
 #' @keywords internal
 inferences_bootstrap <- function(
   object,
+  engine,
   n_boot,
   workers,
   conf_level,
@@ -31,6 +33,8 @@ inferences_bootstrap <- function(
   update_datadist,
   use_coefstart
 ) {
+  engine <- match.arg(engine, choices = c("standard", "fwb"))
+
   # Bootstrap only supports avg_sops for now
   if (!inherits(object, "markov_avg_sops")) {
     stop(
@@ -69,7 +73,10 @@ inferences_bootstrap <- function(
   # --- 2. Validate Data is Longitudinal (Not Just Baseline) ---
   # Check if tvarname exists and has multiple time points per patient
   if (tvarname %in% names(newdata_orig)) {
-    rows_per_patient <- tabulate(match(newdata_orig[[id_var]], unique(newdata_orig[[id_var]])))
+    rows_per_patient <- tabulate(match(
+      newdata_orig[[id_var]],
+      unique(newdata_orig[[id_var]])
+    ))
 
     if (all(rows_per_patient == 1)) {
       stop(
@@ -90,15 +97,13 @@ inferences_bootstrap <- function(
   factor_cols <- c("y", pvarname, p2varname)
   factor_cols <- intersect(factor_cols, names(newdata_orig))
 
-  # --- 3. Generate Bootstrap ID Samples ---
-  boot_ids <- fast_group_bootstrap(
-    data = newdata_orig,
-    id_var = id_var,
-    n_boot = n_boot
-  )
-
   # --- 4. Define Analysis Function ---
-  analysis_fn <- function(boot_data) {
+  analysis_fn <- function(boot_data, fwb_weights = NULL) {
+    fit_weights <- NULL
+    if (engine == "fwb") {
+      fit_weights <- boot_data$fwb_weight
+    }
+
     # A. Relevel factors and refit model
     boot_result <- bootstrap_analysis_wrapper(
       boot_data = boot_data,
@@ -108,7 +113,8 @@ inferences_bootstrap <- function(
       ylevels = ylevels,
       absorb = absorb,
       update_datadist = update_datadist,
-      use_coefstart = use_coefstart
+      use_coefstart = use_coefstart,
+      fit_weights = fit_weights
     )
 
     m_boot <- boot_result$model
@@ -129,7 +135,17 @@ inferences_bootstrap <- function(
 
     # B. Compute standardized SOPs using G-computation on bootstrap data
     # Extract baseline data (one row per patient)
-    baseline_boot <- boot_data[!duplicated(boot_data[["new_id"]]), ]
+    if (engine == "standard") {
+      baseline_boot <- boot_data[!duplicated(boot_data[["new_id"]]), ]
+      baseline_weights <- NULL
+    } else {
+      baseline_boot <- boot_data[!duplicated(boot_data[[id_var]]), ]
+      baseline_weights <- fwb_baseline_weights(
+        fwb_weights = fwb_weights,
+        baseline_data = baseline_boot,
+        id_var = id_var
+      )
+    }
 
     # Create counterfactual datasets for each variable value
     grid <- do.call(expand.grid, variables)
@@ -161,23 +177,26 @@ inferences_bootstrap <- function(
 
     # C. Marginalize (average) across patients for each counterfactual
     # sops_array is [n_pat, n_times, n_boot_states]
-    n_pat <- dim(sops_array)[1]
-    n_boot_states <- dim(sops_array)[3]
     n_cf <- nrow(grid)
-    n_each <- n_pat %/% n_cf
+    n_each <- nrow(baseline_boot)
+    boot_avg <- marginalize_sops_array(
+      sops_array = sops_array,
+      grid = grid,
+      times = times,
+      ylevels = factor(boot_ylevels),
+      variables = variables,
+      n_cf = n_cf,
+      n_each = n_each,
+      weights = baseline_weights
+    )
 
-    # Average within each counterfactual group
-    avg_sops_list <- vector("list", n_cf)
-    for (cf_i in seq_len(n_cf)) {
-      start_idx <- (cf_i - 1) * n_each + 1
-      end_idx <- cf_i * n_each
-
-      # Subset and average [n_each x n_times x n_boot_states]
-      sops_cf <- sops_array[start_idx:end_idx, , , drop = FALSE]
-      avg_sops_mat <- apply(sops_cf, c(2, 3), mean) # [n_times x n_boot_states]
-
-      avg_sops_list[[cf_i]] <- avg_sops_mat
-    }
+    avg_sops_list <- bootstrap_avg_df_to_matrices(
+      boot_avg = boot_avg,
+      grid = grid,
+      times = times,
+      states = factor(boot_ylevels),
+      variables = variables
+    )
 
     # D. Expand back to original state space with zero-padding
     if (length(missing_states) > 0) {
@@ -216,31 +235,75 @@ inferences_bootstrap <- function(
   }
 
   # --- 5. Apply to Bootstrap Samples ---
-  boot_results <- apply_to_bootstrap(
-    boot_samples = boot_ids,
-    analysis_fn = analysis_fn,
-    data = newdata_orig,
-    id_var = id_var,
-    workers = workers,
-    packages = c("rms", "VGAM", "Hmisc", "stats"),
-    globals = c(
-      "model",
-      "variables",
-      "times",
-      "ylevels",
-      "absorb",
-      "pvarname",
-      "p2varname",
-      "tvarname",
-      "gap",
-      "t_covs",
-      "n_times",
-      "n_states",
-      "update_datadist",
-      "factor_cols",
-      "use_coefstart"
+  if (engine == "standard") {
+    boot_ids <- fast_group_bootstrap(
+      data = newdata_orig,
+      id_var = id_var,
+      n_boot = n_boot
     )
-  )
+
+    boot_results <- apply_to_bootstrap(
+      boot_samples = boot_ids,
+      analysis_fn = analysis_fn,
+      data = newdata_orig,
+      id_var = id_var,
+      workers = workers,
+      packages = c("rms", "VGAM", "Hmisc", "stats"),
+      globals = c(
+        "model",
+        "variables",
+        "times",
+        "ylevels",
+        "absorb",
+        "pvarname",
+        "p2varname",
+        "tvarname",
+        "gap",
+        "t_covs",
+        "n_times",
+        "n_states",
+        "update_datadist",
+        "factor_cols",
+        "use_coefstart",
+        "engine",
+        "id_var"
+      )
+    )
+  } else {
+    fwb_samples <- generate_fwb_bootstrap_weights(
+      data = newdata_orig,
+      id_var = id_var,
+      n_boot = n_boot
+    )
+
+    boot_results <- apply_to_fwb_bootstrap(
+      fwb_samples = fwb_samples,
+      analysis_fn = analysis_fn,
+      data = newdata_orig,
+      id_var = id_var,
+      workers = workers,
+      packages = c("rms", "VGAM", "Hmisc", "stats"),
+      globals = c(
+        "model",
+        "variables",
+        "times",
+        "ylevels",
+        "absorb",
+        "pvarname",
+        "p2varname",
+        "tvarname",
+        "gap",
+        "t_covs",
+        "n_times",
+        "n_states",
+        "update_datadist",
+        "factor_cols",
+        "use_coefstart",
+        "engine",
+        "id_var"
+      )
+    )
+  }
 
   # --- 6. Combine and Compute Summary Statistics ---
   boot_results <- Filter(Negate(is.null), boot_results)
@@ -278,6 +341,11 @@ inferences_bootstrap <- function(
   attr(final_result, "n_successful") <- length(boot_results)
   attr(final_result, "conf_level") <- conf_level
   attr(final_result, "method") <- "bootstrap"
+  attr(final_result, "engine") <- engine
+  if (engine == "fwb") {
+    attr(final_result, "fwb_weight_type") <- "exponential"
+    attr(final_result, "fwb_weight_scale") <- "cluster_mean_1"
+  }
 
   # Store full bootstrap draws if requested
   if (return_draws) {
@@ -291,3 +359,31 @@ inferences_bootstrap <- function(
 # =============================================================================
 # HELPER FUNCTIONS FOR INFERENCE
 # =============================================================================
+
+bootstrap_avg_df_to_matrices <- function(
+  boot_avg,
+  grid,
+  times,
+  states,
+  variables
+) {
+  out <- vector("list", nrow(grid))
+
+  for (cf_i in seq_len(nrow(grid))) {
+    keep <- rep(TRUE, nrow(boot_avg))
+    for (v in names(variables)) {
+      keep <- keep & boot_avg[[v]] == grid[[v]][cf_i]
+    }
+
+    df <- boot_avg[keep, , drop = FALSE]
+    mat <- matrix(
+      df$estimate,
+      nrow = length(times),
+      ncol = length(states),
+      byrow = FALSE
+    )
+    out[[cf_i]] <- mat
+  }
+
+  out
+}

--- a/R/sops-inference.R
+++ b/R/sops-inference.R
@@ -17,13 +17,17 @@
 #'     \item `"bootstrap"`: Resamples patients with replacement, refits model.
 #'  Only works for `markov_avg_sops` objects.
 #'   }
-#' @param engine Character. Simulation engine used when `method = "simulation"`:
+#' @param engine Character. Inference engine. For `method = "simulation"`:
 #'   \itemize{
 #'     \item `"mvn"` (default): Draws coefficients from MVN(beta_hat, Sigma).
 #'     \item `"score_bootstrap"`: Uses one-step score perturbation with
 #'       cluster-level exponential multipliers. Requires a `robcov_vglm` model
 #'       or an `orm` model with `cluster`, and `avg_sops()` objects.
 #'   }
+#'   For `method = "bootstrap"`, use `"standard"` for ordinary patient
+#'   resampling with replacement or `"fwb"` for fractional weighted bootstrap
+#'   refits using exponential patient-level weights. The legacy default
+#'   `"mvn"` maps to `"standard"` when `method = "bootstrap"`.
 #' @param score_weight_dist Character. Cluster weight distribution for
 #'   `engine = "score_bootstrap"`. Currently only `"exponential"` is supported.
 #' @param n_sim Number of simulation draws (for simulation) or bootstrap
@@ -85,8 +89,9 @@
 #'
 #' ## Bootstrap Method
 #'
-#' The bootstrap method resamples patients and refits the model:
-#' 1. Sample patient IDs with replacement
+#' The bootstrap method refits the model on bootstrap-weighted data:
+#' 1. Sample patient IDs with replacement (`engine = "standard"`) or draw
+#'    exponential patient weights normalized to mean 1 (`engine = "fwb"`)
 #' 2. Refit model on bootstrap sample (handles missing states through releveling)
 #' 3. Compute SOPs using G-computation
 #' 4. Compute percentile-based confidence intervals
@@ -228,10 +233,23 @@ inferences <- function(
   }
 
   method <- match.arg(method, choices = c("simulation", "bootstrap"))
-  engine <- match.arg(engine, choices = c("mvn", "score_bootstrap"))
+  engine <- match.arg(
+    engine,
+    choices = c("mvn", "score_bootstrap", "standard", "fwb")
+  )
 
-  if (method == "bootstrap" && engine != "mvn") {
-    stop("`engine` is only used when `method = \"simulation\"`.")
+  if (method == "simulation" && engine %in% c("standard", "fwb")) {
+    stop(
+      "`engine = \"",
+      engine,
+      "\"` is only used when `method = \"bootstrap\"`."
+    )
+  }
+  if (method == "bootstrap" && engine == "score_bootstrap") {
+    stop(
+      "`engine = \"score_bootstrap\"` is only used when ",
+      "`method = \"simulation\"`."
+    )
   }
 
   # --- Dispatch to Method-Specific Implementation ---
@@ -249,8 +267,10 @@ inferences <- function(
       return_draws = return_draws
     )
   } else if (method == "bootstrap") {
+    bootstrap_engine <- if (engine == "mvn") "standard" else engine
     inferences_bootstrap(
       object = object,
+      engine = bootstrap_engine,
       n_boot = n_sim,
       workers = workers,
       conf_level = conf_level,

--- a/man/bootstrap_analysis_wrapper.Rd
+++ b/man/bootstrap_analysis_wrapper.Rd
@@ -12,7 +12,8 @@ bootstrap_analysis_wrapper(
   ylevels = NULL,
   absorb = NULL,
   update_datadist = TRUE,
-  use_coefstart = FALSE
+  use_coefstart = FALSE,
+  fit_weights = NULL
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ c("y", "yprev"))}
 
 \item{use_coefstart}{Logical indicating whether to use starting coefficients
 from the original model when refitting (only for vglm models).}
+
+\item{fit_weights}{Optional non-negative row weights for the bootstrap fit.}
 }
 \value{
 A list with components:

--- a/man/inferences.Rd
+++ b/man/inferences.Rd
@@ -33,13 +33,17 @@ refit models. Works for both individual and averaged SOPs.
 Only works for \code{markov_avg_sops} objects.
 }}
 
-\item{engine}{Character. Simulation engine used when \code{method = "simulation"}:
+\item{engine}{Character. Inference engine. For \code{method = "simulation"}:
 \itemize{
 \item \code{"mvn"} (default): Draws coefficients from MVN(beta_hat, Sigma).
 \item \code{"score_bootstrap"}: Uses one-step score perturbation with
 cluster-level exponential multipliers. Requires a \code{robcov_vglm} model
 or an \code{orm} model with \code{cluster}, and \code{avg_sops()} objects.
-}}
+}
+For \code{method = "bootstrap"}, use \code{"standard"} for ordinary patient
+resampling with replacement or \code{"fwb"} for fractional weighted bootstrap
+refits using exponential patient-level weights. The legacy default
+\code{"mvn"} maps to \code{"standard"} when \code{method = "bootstrap"}.}
 
 \item{score_weight_dist}{Character. Cluster weight distribution for
 \code{engine = "score_bootstrap"}. Currently only \code{"exponential"} is supported.}
@@ -124,9 +128,10 @@ models and with \code{orm} models when \code{cluster} is supplied.
 
 \subsection{Bootstrap Method}{
 
-The bootstrap method resamples patients and refits the model:
+The bootstrap method refits the model on bootstrap-weighted data:
 \enumerate{
-\item Sample patient IDs with replacement
+\item Sample patient IDs with replacement (\code{engine = "standard"}) or draw
+exponential patient weights normalized to mean 1 (\code{engine = "fwb"})
 \item Refit model on bootstrap sample (handles missing states through releveling)
 \item Compute SOPs using G-computation
 \item Compute percentile-based confidence intervals

--- a/man/inferences_bootstrap.Rd
+++ b/man/inferences_bootstrap.Rd
@@ -6,6 +6,7 @@
 \usage{
 inferences_bootstrap(
   object,
+  engine,
   n_boot,
   workers,
   conf_level,
@@ -16,6 +17,8 @@ inferences_bootstrap(
 }
 \arguments{
 \item{object}{A \code{markov_avg_sops} object.}
+
+\item{engine}{Bootstrap engine, \code{"standard"} or \code{"fwb"}.}
 
 \item{n_boot}{Number of bootstrap iterations.}
 

--- a/man/sim_actt2_brownian.Rd
+++ b/man/sim_actt2_brownian.Rd
@@ -18,8 +18,10 @@ sim_actt2_brownian(
 \item{treatment_prob}{Numeric. Probability of assignment to treatment group
 (default: 0.5).}
 
-\item{mu_treatment_effect}{Numeric. Additional constant drift for treatment
-group (default: 0, meaning no arm difference).}
+\item{mu_treatment_effect}{Numeric scalar or vector of length 7. Additional
+threshold-specific drift for the treatment group (default: 0, meaning no
+arm difference). Vector element \code{j} affects the boundary between states \code{j}
+and \code{j + 1}.}
 
 \item{seed}{Integer. Random seed for reproducibility (default: NULL).}
 
@@ -37,6 +39,8 @@ simulator with defaults tuned to roughly preserve control-arm state
 occupancy while reducing rehospitalization-like movement from recovered
 states 1/2 into states 3:7. The defaults are null-aligned, so there is no
 built-in treatment difference unless \code{mu_treatment_effect} is changed.
+\code{mu_treatment_effect} may be a scalar, which affects every threshold equally,
+or a vector with one value per threshold.
 }
 \details{
 This is intended as a convenient starting point for simulation studies, not
@@ -49,6 +53,12 @@ actt2_null <- sim_actt2_brownian(n_patients = 1000, seed = 123)
 actt2_alt <- sim_actt2_brownian(
   n_patients = 1000,
   mu_treatment_effect = -0.03,
+  seed = 123
+)
+
+actt2_state5_to_6 <- sim_actt2_brownian(
+  n_patients = 1000,
+  mu_treatment_effect = c(0, 0, 0, 0, 0.03, 0, 0),
   seed = 123
 )
 }

--- a/man/sim_trajectories_brownian_gap.Rd
+++ b/man/sim_trajectories_brownian_gap.Rd
@@ -23,7 +23,6 @@ sim_trajectories_brownian_gap(
   drift_start = 0,
   latent_dist = c("logistic", "normal"),
   refresh_rate = 0.048,
-  threshold_time_effect_factors = NULL,
   seed = NULL
 )
 }
@@ -34,20 +33,27 @@ sim_trajectories_brownian_gap(
 
 \item{n_states}{Integer. Number of ordered states/categories (default: 6).}
 
-\item{mu_drift}{Numeric. Baseline (constant) drift per day for control group
-(default: -0.26). Negative values indicate improvement.}
+\item{mu_drift}{Numeric scalar or vector of length \code{n_states - 1}. Baseline
+threshold-specific drift per day for the control group (default: -0.26).
+Negative values indicate improvement. Vector element \code{j} affects threshold
+\code{j}, the boundary between states \code{j} and \code{j + 1}.}
 
 \item{mu_drift_sd}{Numeric. Standard deviation of a patient-specific random
 drift component added to \code{mu_drift} (default: 0). This induces persistent
 heterogeneity in individual improvement or worsening rates over follow-up.}
 
-\item{mu_quad}{Numeric. Quadratic coefficient for time-varying drift
-(default: 0.006).}
+\item{mu_quad}{Numeric scalar or vector of length \code{n_states - 1}. Quadratic
+coefficient for threshold-specific time-varying drift (default: 0.006).}
 
-\item{mu_quad2}{Numeric. Second-order quadratic coefficient for drift (default: 0).}
+\item{mu_quad2}{Numeric scalar or vector of length \code{n_states - 1}.
+Second-order quadratic coefficient for threshold-specific drift (default:
+0).}
 
-\item{mu_treatment_effect}{Numeric. Additional constant drift for treatment group
-(default: -0.04). Negative values indicate faster improvement with treatment.}
+\item{mu_treatment_effect}{Numeric scalar or vector of length \code{n_states - 1}.
+Additional threshold-specific drift for the treatment group (default:
+-0.04). Negative values indicate faster improvement with treatment. To
+target a single adjacent-state boundary, set only that vector element to a
+nonzero value.}
 
 \item{sigma_rw}{Numeric. Random walk innovation standard deviation per day
 (default: 0.12).}
@@ -85,12 +91,6 @@ to observed states. Options are "logistic" (default) or "normal".}
 non-absorbing state refresh (default: 0.048). Lower values create longer
 dwell times between observed state updates.}
 
-\item{threshold_time_effect_factors}{Numeric vector of length K-1 or \code{NULL}.
-Multipliers for how strongly the common deterministic latent drift affects
-each threshold over time (default: \code{NULL}, equivalent to all 1s). Values
-below 1 attenuate the time effect for a threshold; values above 1 amplify
-it. The induced day-specific thresholds must remain strictly increasing.}
-
 \item{seed}{Integer. Random seed for reproducibility (default: NULL).}
 }
 \value{
@@ -100,7 +100,7 @@ A data frame (tibble) with columns:
 \item time: time/day (1 to follow_up_time)
 \item tx: treatment assignment (0 = control, 1 = treatment)
 \item y: observed ordinal state at time
-\item x: latent continuous severity
+\item x: reference latent continuous severity
 }
 }
 \description{
@@ -115,6 +115,9 @@ evolution from observed-state refresh:
 \enumerate{
 \item Each patient has an unobserved continuous "severity" X(t) that evolves
 daily as a Gaussian random walk with drift.
+\item When drift parameters are threshold-specific vectors, \code{x} follows a
+reference latent drift while observed-state probabilities are generated
+from threshold-specific cutpoint trajectories.
 \item A patient-specific waiting time to the next refresh is drawn from an
 exponential distribution with rate \code{refresh_rate}.
 \item Between refresh dates, non-absorbing observed states are carried forward.
@@ -134,6 +137,13 @@ traj_gap <- sim_trajectories_brownian_gap(
 traj_gap_low_switch <- sim_trajectories_brownian_gap(
   n_patients = 1000,
   refresh_rate = 0.02,
+  seed = 12345
+)
+
+# Treatment effect only at the state 5/6 boundary
+traj_gap_targeted <- sim_trajectories_brownian_gap(
+  n_patients = 1000,
+  mu_treatment_effect = c(0, 0, 0, 0, -0.04),
   seed = 12345
 )
 }

--- a/tests/testthat/_snaps/sops-inferences.md
+++ b/tests/testthat/_snaps/sops-inferences.md
@@ -97,7 +97,7 @@
       ]
     }
 
-# avg_sops() and inferences() pipeline / Brownian avg_sops() supports bootstrap inference
+# avg_sops() and inferences() pipeline / avg_sops() supports standard bootstrap inference
 
     {
       "type": "list",
@@ -196,7 +196,7 @@
       ]
     }
 
-# avg_sops() and inferences() pipeline / Brownian avg_sops() supports score-bootstrap simulation on the fast path
+# avg_sops() and inferences() pipeline / avg_sops() supports score-bootstrap simulation on the fast path
 
     {
       "type": "list",

--- a/tests/testthat/test-bootstrap_helpers.R
+++ b/tests/testthat/test-bootstrap_helpers.R
@@ -45,6 +45,65 @@ test_that("materialize_bootstrap_sample preserves sampled copies and row data", 
   expect_equal(result$y, c(1, 0, 0, 1, 1, 0))
 })
 
+test_that("fractional bootstrap weights are mean-one cluster weights", {
+  data <- data.frame(
+    id = c("a", "a", "b", "c", "c"),
+    value = 1:5
+  )
+
+  withr::local_seed(123)
+  boot_a <- markov.misc:::generate_fwb_bootstrap_weights(
+    data,
+    id_var = "id",
+    n_boot = 2
+  )
+  withr::local_seed(123)
+  boot_b <- markov.misc:::generate_fwb_bootstrap_weights(
+    data,
+    id_var = "id",
+    n_boot = 2
+  )
+
+  expect_equal(boot_a, boot_b)
+  expect_length(boot_a, 2)
+  expect_named(boot_a[[1]], c("original_id", "fwb_weight", "boot_id"))
+  expect_equal(boot_a[[1]]$original_id, c("a", "b", "c"))
+  expect_true(all(boot_a[[1]]$fwb_weight > 0))
+  expect_equal(mean(boot_a[[1]]$fwb_weight), 1, tolerance = 1e-12)
+  expect_equal(boot_a[[2]]$boot_id, rep(2, 3))
+})
+
+test_that("fractional bootstrap materialization expands cluster weights to rows", {
+  data <- data.frame(
+    id = c(1, 1, 2, 2),
+    time = c(1, 2, 1, 2),
+    y = c(0, 1, 1, 0)
+  )
+  fwb_weights <- data.frame(
+    original_id = c(1, 2),
+    fwb_weight = c(0.25, 1.75),
+    boot_id = 1
+  )
+
+  result <- markov.misc:::materialize_fwb_bootstrap_sample(
+    fwb_weights,
+    data,
+    "id"
+  )
+
+  expect_equal(nrow(result), nrow(data))
+  expect_equal(result$fwb_weight, c(0.25, 0.25, 1.75, 1.75))
+  expect_equal(result$boot_id, rep(1, 4))
+  expect_equal(
+    markov.misc:::fwb_baseline_weights(
+      fwb_weights,
+      data[!duplicated(data$id), ],
+      "id"
+    ),
+    c(0.25, 1.75)
+  )
+})
+
 test_that("apply_to_bootstrap materializes samples before sequential analysis", {
   data <- data.frame(
     id = c(1, 1, 2, 2),
@@ -67,6 +126,66 @@ test_that("apply_to_bootstrap materializes samples before sequential analysis", 
 
   expect_equal(result[[1]], c(rows = 4, total = 33))
   expect_equal(result[[2]], c(rows = 4, total = 60))
+})
+
+test_that("apply_to_fwb_bootstrap materializes weights before analysis", {
+  data <- data.frame(
+    id = c(1, 1, 2, 2),
+    y = c(1, 2, 10, 20)
+  )
+  fwb_samples <- list(
+    data.frame(original_id = c(1, 2), fwb_weight = c(0.5, 1.5), boot_id = 1),
+    data.frame(original_id = c(1, 2), fwb_weight = c(1.2, 0.8), boot_id = 2)
+  )
+
+  result <- markov.misc:::apply_to_fwb_bootstrap(
+    fwb_samples = fwb_samples,
+    analysis_fn = function(boot_data, fwb_weights) {
+      c(
+        rows = nrow(boot_data),
+        total = sum(boot_data$y * boot_data$fwb_weight),
+        n_weights = nrow(fwb_weights)
+      )
+    },
+    data = data,
+    id_var = "id",
+    workers = 1
+  )
+
+  expect_equal(result[[1]], c(rows = 4, total = 46.5, n_weights = 2))
+  expect_equal(result[[2]], c(rows = 4, total = 27.6, n_weights = 2))
+})
+
+test_that("apply_to_fwb_bootstrap works with parallel workers", {
+  future::plan(future::sequential)
+  withr::defer(future::plan(future::sequential))
+
+  data <- data.frame(
+    id = c(1, 1, 2, 2),
+    y = c(1, 2, 10, 20)
+  )
+  fwb_samples <- list(
+    data.frame(original_id = c(1, 2), fwb_weight = c(0.5, 1.5), boot_id = 1)
+  )
+
+  result <- suppressWarnings(
+    markov.misc:::apply_to_fwb_bootstrap(
+      fwb_samples = fwb_samples,
+      analysis_fn = function(boot_data, fwb_weights) {
+        c(
+          total = sum(boot_data$y * boot_data$fwb_weight),
+          n_weights = nrow(fwb_weights)
+        )
+      },
+      data = data,
+      id_var = "id",
+      workers = 2,
+      packages = character(0)
+    )
+  )
+
+  expect_equal(result[[1]], c(total = 46.5, n_weights = 2))
+  expect_equal(future::nbrOfWorkers(), 1L)
 })
 
 test_that("apply_to_bootstrap maps deprecated parallel argument to workers", {
@@ -225,18 +344,64 @@ test_that("bootstrap_analysis_wrapper scopes orm datadist updates", {
   withr::defer(options(datadist = NULL))
   withr::defer(rm("dd", envir = globalenv()))
 
-  boot_data <- data.frame(y = factor(c(1, 2, 3)), x = c(0, 1, 2))
-  result <- bootstrap_analysis_wrapper(
-    boot_data = boot_data,
-    model = structure(list(), class = "orm"),
-    factor_cols = "y",
-    original_data = boot_data,
-    update_datadist = TRUE
+  boot_data <- data.frame(
+    y = factor(c(1, 2, 3)),
+    x = c(0, 1, 2),
+    boot_id = 1,
+    fwb_weight = c(0.5, 1, 1.5),
+    .markov_misc_fit_weight = c(0.5, 1, 1.5)
+  )
+  result <- expect_no_warning(
+    bootstrap_analysis_wrapper(
+      boot_data = boot_data,
+      model = structure(list(), class = "orm"),
+      factor_cols = "y",
+      original_data = boot_data,
+      update_datadist = TRUE
+    )
   )
 
   expect_s3_class(result$model, "orm")
   expect_equal(getOption("datadist"), "existing_dd")
   expect_identical(get("dd", envir = globalenv()), old_dd)
+})
+
+test_that("update_bootstrap_model suppresses only known orm weight warning", {
+  update.orm <- function(object, data, weights = NULL, ...) {
+    warning(
+      "currently weights are ignored in model validation and bootstrapping orm fits",
+      call. = FALSE
+    )
+    structure(list(data = data), class = "orm")
+  }
+  assign("update.orm", update.orm, envir = globalenv())
+  withr::defer(rm("update.orm", envir = globalenv()))
+
+  boot_data <- data.frame(y = 1:3, .markov_misc_fit_weight = c(0.5, 1, 1.5))
+
+  result <- expect_no_warning(
+    markov.misc:::update_bootstrap_model(
+      structure(list(), class = "orm"),
+      boot_data,
+      fit_weights = boot_data$.markov_misc_fit_weight
+    )
+  )
+  expect_s3_class(result, "orm")
+
+  update.orm <- function(object, data, weights = NULL, ...) {
+    warning("important warning", call. = FALSE)
+    structure(list(data = data), class = "orm")
+  }
+  assign("update.orm", update.orm, envir = globalenv())
+
+  expect_warning(
+    markov.misc:::update_bootstrap_model(
+      structure(list(), class = "orm"),
+      boot_data,
+      fit_weights = boot_data$.markov_misc_fit_weight
+    ),
+    "important warning"
+  )
 })
 
 test_that("bootstrap_analysis_wrapper falls back when coefstart update fails", {
@@ -269,4 +434,82 @@ test_that("bootstrap_analysis_wrapper falls back when coefstart update fails", {
 
   expect_s3_class(result$model, "vglm")
   expect_equal(result$model$data, boot_data)
+})
+
+test_that("bootstrap_analysis_wrapper multiplies original and fractional weights", {
+  update.mock_weighted <- function(object, data, weights = NULL, ...) {
+    weight_expr <- substitute(weights)
+    structure(
+      list(
+        data = data,
+        weights = eval(weight_expr, data, parent.frame())
+      ),
+      class = "mock_weighted"
+    )
+  }
+  assign("update.mock_weighted", update.mock_weighted, envir = globalenv())
+  withr::defer(rm("update.mock_weighted", envir = globalenv()))
+
+  original_data <- data.frame(
+    y = factor(c(1, 2, 3)),
+    x = c(0, 1, 2),
+    w = c(2, 3, 4)
+  )
+  boot_data <- original_data
+  model <- structure(
+    list(call = quote(mock_fit(y ~ x, data = original_data, weights = w))),
+    class = "mock_weighted"
+  )
+
+  result <- bootstrap_analysis_wrapper(
+    boot_data = boot_data,
+    model = model,
+    factor_cols = "y",
+    original_data = original_data,
+    update_datadist = FALSE,
+    fit_weights = c(0.5, 1, 1.5)
+  )
+
+  expect_s3_class(result$model, "mock_weighted")
+  expect_equal(result$model$weights, c(1, 3, 6))
+  expect_equal(result$model$data$.markov_misc_fit_weight, c(1, 3, 6))
+})
+
+test_that("bootstrap_analysis_wrapper recovers stored fit weights", {
+  make_weighted_lm <- function() {
+    original_data <- data.frame(
+      y = c(1, 2, 3, 4),
+      x = c(0, 1, 2, 3)
+    )
+    original_weights <- c(2, 3, 4, 5)
+
+    list(
+      model = stats::lm(
+        y ~ x,
+        data = original_data,
+        weights = original_weights
+      ),
+      data = original_data
+    )
+  }
+
+  weighted_fit <- make_weighted_lm()
+
+  result <- expect_no_warning(
+    bootstrap_analysis_wrapper(
+      boot_data = weighted_fit$data,
+      model = weighted_fit$model,
+      factor_cols = character(0),
+      original_data = weighted_fit$data,
+      update_datadist = FALSE,
+      fit_weights = c(0.5, 1, 1.5, 2)
+    )
+  )
+
+  expect_s3_class(result$model, "lm")
+  expect_equal(result$model$weights, c(1, 3, 6, 10))
+  expect_equal(
+    result$model$model[["(weights)"]],
+    c(1, 3, 6, 10)
+  )
 })

--- a/tests/testthat/test-internal-helpers.R
+++ b/tests/testthat/test-internal-helpers.R
@@ -570,7 +570,7 @@ test_that("standardize_sops and inferences validate dispatch-only branches", {
   class(object) <- c("markov_avg_sops", class(object))
   expect_error(
     inferences(object, method = "bootstrap", engine = "score_bootstrap"),
-    "`engine` is only used",
+    "only used when `method = \"simulation\"`",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-simulate_trajectories.R
+++ b/tests/testthat/test-simulate_trajectories.R
@@ -172,6 +172,19 @@ test_that("sim_actt2_brownian uses a null treatment effect by default", {
   expect_identical(traj_default, traj_null)
 })
 
+test_that("sim_actt2_brownian allows overriding threshold-specific time effects", {
+  direct_drift <- sim_actt2_brownian(
+    n_patients = 40,
+    mu_drift = rep(-2.2, 7),
+    seed = 99
+  )
+  default_drift <- sim_actt2_brownian(n_patients = 40, seed = 99)
+
+  expect_identical(names(direct_drift), names(default_drift))
+  expect_identical(dim(direct_drift), dim(default_drift))
+  expect_gt(sum(direct_drift$y != default_drift$y), 0)
+})
+
 test_that("sim_trajectories_markov validates inputs and absent covariates", {
   baseline <- data.frame(id = 1:2, yprev = c(1, 1))
 
@@ -305,7 +318,11 @@ test_that("sim_trajectories_brownian validates inputs and supports normal link o
     fixed = TRUE
   )
   expect_error(
-    sim_trajectories_brownian(n_states = 3, allowed_start_state = 4L, thresholds = c(0, 1)),
+    sim_trajectories_brownian(
+      n_states = 3,
+      allowed_start_state = 4L,
+      thresholds = c(0, 1)
+    ),
     "All allowed_start_state must be between 1 and n_states",
     fixed = TRUE
   )
@@ -354,8 +371,14 @@ test_that("sim_trajectories_brownian applies late piecewise drift", {
 })
 
 test_that("sim_trajectories_brownian_gap validates additional inputs", {
-  expect_error(sim_trajectories_brownian_gap(n_patients = 0), "n_patients must be")
-  expect_error(sim_trajectories_brownian_gap(follow_up_time = 0), "follow_up_time must be")
+  expect_error(
+    sim_trajectories_brownian_gap(n_patients = 0),
+    "n_patients must be"
+  )
+  expect_error(
+    sim_trajectories_brownian_gap(follow_up_time = 0),
+    "follow_up_time must be"
+  )
   expect_error(sim_trajectories_brownian_gap(n_states = 1), "n_states must be")
   expect_error(
     sim_trajectories_brownian_gap(n_states = 3, thresholds = 0),
@@ -366,8 +389,20 @@ test_that("sim_trajectories_brownian_gap validates additional inputs", {
     "thresholds must be a strictly increasing"
   )
   expect_error(
-    sim_trajectories_brownian_gap(threshold_time_effect_factors = c(0, 1)),
-    "threshold_time_effect_factors must be NULL"
+    sim_trajectories_brownian_gap(mu_drift = c(0, 1)),
+    "mu_drift must be a finite numeric scalar"
+  )
+  expect_error(
+    sim_trajectories_brownian_gap(mu_quad = c(0, 1)),
+    "mu_quad must be a finite numeric scalar"
+  )
+  expect_error(
+    sim_trajectories_brownian_gap(mu_quad2 = Inf),
+    "mu_quad2 must be a finite numeric scalar"
+  )
+  expect_error(
+    sim_trajectories_brownian_gap(mu_treatment_effect = c(0, 1)),
+    "mu_treatment_effect must be a finite numeric scalar"
   )
   expect_error(
     sim_trajectories_brownian_gap(drift_start = -1),
@@ -378,19 +413,23 @@ test_that("sim_trajectories_brownian_gap validates additional inputs", {
     "drift_start must be a non-negative numeric scalar"
   )
   expect_error(
-    sim_trajectories_brownian_gap(
-      thresholds = c(-1, 0, 1, 2, 3),
-      threshold_time_effect_factors = c(0, 10, 0, 0, 0)
-    ),
-    "threshold_time_effect_factors induce crossing thresholds"
+    sim_trajectories_brownian_gap(mu_drift = c(0, 100, 0, 0, 0)),
+    "threshold-specific drift terms induce crossing thresholds"
   )
-  expect_error(sim_trajectories_brownian_gap(treatment_prob = -1), "treatment_prob must")
+  expect_error(
+    sim_trajectories_brownian_gap(treatment_prob = -1),
+    "treatment_prob must"
+  )
   expect_error(
     sim_trajectories_brownian_gap(allowed_start_state = c(1, 2)),
     "allowed_start_state must"
   )
   expect_error(
-    sim_trajectories_brownian_gap(n_states = 3, allowed_start_state = 4L, thresholds = c(0, 1)),
+    sim_trajectories_brownian_gap(
+      n_states = 3,
+      allowed_start_state = 4L,
+      thresholds = c(0, 1)
+    ),
     "All allowed_start_state"
   )
   expect_error(
@@ -422,6 +461,31 @@ test_that("sim_trajectories_brownian_gap validates additional inputs", {
 
   expect_equal(nrow(result), 12)
   expect_true(all(result$y %in% 1:3))
+})
+
+test_that("sim_trajectories_brownian_gap supports threshold-specific treatment effects", {
+  traj_null <- sim_trajectories_brownian_gap(
+    n_patients = 80,
+    follow_up_time = 8,
+    treatment_prob = 1,
+    absorbing_state = NULL,
+    refresh_rate = 100,
+    mu_treatment_effect = 0,
+    seed = 12
+  )
+  traj_targeted <- sim_trajectories_brownian_gap(
+    n_patients = 80,
+    follow_up_time = 8,
+    treatment_prob = 1,
+    absorbing_state = NULL,
+    refresh_rate = 100,
+    mu_treatment_effect = c(0, 0, 0, 0, -0.8),
+    seed = 12
+  )
+
+  expect_identical(names(traj_null), names(traj_targeted))
+  expect_identical(dim(traj_null), dim(traj_targeted))
+  expect_gt(sum(traj_null$y != traj_targeted$y), 0)
 })
 
 test_that("sim_trajectories_brownian_gap handles piecewise drift and zero transition mass", {
@@ -456,8 +520,14 @@ test_that("sim_trajectories_brownian_gap reaches both piecewise drift tails", {
 })
 
 test_that("sim_trajectories_deterministic validates inputs and returns trajectories", {
-  expect_error(sim_trajectories_deterministic(n_patients = 0), "n_patients must")
-  expect_error(sim_trajectories_deterministic(follow_up_time = 0), "follow_up_time must")
+  expect_error(
+    sim_trajectories_deterministic(n_patients = 0),
+    "n_patients must"
+  )
+  expect_error(
+    sim_trajectories_deterministic(follow_up_time = 0),
+    "follow_up_time must"
+  )
   expect_error(sim_trajectories_deterministic(n_states = 1), "n_states must")
   expect_error(
     sim_trajectories_deterministic(mortality_prob_control = -0.1),
@@ -467,7 +537,10 @@ test_that("sim_trajectories_deterministic validates inputs and returns trajector
     sim_trajectories_deterministic(mortality_prob_treatment = 1.1),
     "mortality_prob_treatment must"
   )
-  expect_error(sim_trajectories_deterministic(treatment_prob = 2), "treatment_prob must")
+  expect_error(
+    sim_trajectories_deterministic(treatment_prob = 2),
+    "treatment_prob must"
+  )
   expect_error(
     sim_trajectories_deterministic(n_states = 5, absorbing_states = 7),
     "All absorbing_states must"
@@ -483,7 +556,10 @@ test_that("sim_trajectories_deterministic validates inputs and returns trajector
     seed = 12
   )
 
-  expect_named(result, c("id", "tx", "theta0", "theta1", "b0", "b1", "time", "y", "x", "yprev"))
+  expect_named(
+    result,
+    c("id", "tx", "theta0", "theta1", "b0", "b1", "time", "y", "x", "yprev")
+  )
   expect_equal(nrow(result), 20)
   expect_equal(min(result$time), 1)
   expect_true(any(result$y %in% c(1, 6)))
@@ -556,14 +632,25 @@ test_that("sim_trajectories_deterministic handles baseline and later absorbing s
 
 test_that("recurr_event simulates events and validates vector parameter lengths", {
   withr::local_seed(1)
-  result <- recurr_event(id = 1:2, param = 0.5, b = 0, follow_up = 10, max_events = 3)
+  result <- recurr_event(
+    id = 1:2,
+    param = 0.5,
+    b = 0,
+    follow_up = 10,
+    max_events = 3
+  )
 
   expect_equal(ncol(result), 2)
   expect_true(all(result[, "id"] %in% 1:2))
   expect_true(all(result[, "event_time"] < 10))
 
   expect_error(
-    recurr_event(id = 1:2, param = c(0.1, 0.2), follow_up = 10, max_events = NULL),
+    recurr_event(
+      id = 1:2,
+      param = c(0.1, 0.2),
+      follow_up = 10,
+      max_events = NULL
+    ),
     "Length of param must be one or equal to max_events",
     fixed = TRUE
   )
@@ -571,7 +658,12 @@ test_that("recurr_event simulates events and validates vector parameter lengths"
 
 test_that("recurr_event auto-selects event counts for scalar and vector rates", {
   withr::local_seed(2)
-  scalar <- recurr_event(param = 0.01, b = 0.001, follow_up = 1, max_events = NULL)
+  scalar <- recurr_event(
+    param = 0.01,
+    b = 0.001,
+    follow_up = 1,
+    max_events = NULL
+  )
   vector <- recurr_event(
     id = 1,
     param = c(0.01, 0.02, 0.03),
@@ -584,7 +676,13 @@ test_that("recurr_event auto-selects event counts for scalar and vector rates", 
   expect_equal(ncol(vector), 2)
 
   expect_warning(
-    recurr_event(id = 1, param = 100, b = 0, follow_up = 100, max_events = NULL),
+    recurr_event(
+      id = 1,
+      param = 100,
+      b = 0,
+      follow_up = 100,
+      max_events = NULL
+    ),
     "max_events = 20",
     fixed = TRUE
   )
@@ -612,7 +710,12 @@ test_that("sim_trajectories_tte validates inputs", {
     fixed = TRUE
   )
   expect_error(
-    sim_trajectories_tte(baseline, states = 1:3, param = rep(0.1, 3), hazard_ratios = list(c(1, 1))),
+    sim_trajectories_tte(
+      baseline,
+      states = 1:3,
+      param = rep(0.1, 3),
+      hazard_ratios = list(c(1, 1))
+    ),
     "Each element of hazard_ratios must have length",
     fixed = TRUE
   )

--- a/tests/testthat/test-sops-inference-errors.R
+++ b/tests/testthat/test-sops-inference-errors.R
@@ -94,6 +94,53 @@ test_that("inferences_simulation() validates stored models and simulation engine
 
 })
 
+test_that("inferences() validates method and engine combinations", {
+  model <- structure(list(coefficients = c(a = 0)), class = "mock_model")
+  newdata <- data.frame(
+    id = rep(1:2, each = 2),
+    time = rep(1:2, times = 2),
+    yprev = 1,
+    tx = 0
+  )
+  object <- make_avg_sops_object(model, newdata)
+
+  expect_error(
+    inferences(object, method = "simulation", engine = "fwb", n_sim = 1),
+    "only used when `method = \"bootstrap\"`",
+    fixed = TRUE
+  )
+  expect_error(
+    inferences(
+      object,
+      method = "bootstrap",
+      engine = "score_bootstrap",
+      n_sim = 1
+    ),
+    "only used when `method = \"simulation\"`",
+    fixed = TRUE
+  )
+
+  seen_engine <- NULL
+  with_mocked_bindings(
+    inferences_bootstrap = function(object, engine, ...) {
+      seen_engine <<- engine
+      attr(object, "engine") <- engine
+      object
+    },
+    {
+      out <- inferences(
+        object,
+        method = "bootstrap",
+        engine = "fwb",
+        n_sim = 1
+      )
+    }
+  )
+
+  expect_equal(seen_engine, "fwb")
+  expect_equal(attr(out, "engine"), "fwb")
+})
+
 test_that("inferences_simulation() falls back when fast-path setup fails", {
   model <- structure(list(coefficients = c(a = 0, b = 0)), class = "vglm")
   newdata <- data.frame(id = 1:2, tx = c(0, 1), yprev = c(1, 2), time = 1)
@@ -425,6 +472,7 @@ test_that("inferences_bootstrap() validates inputs and records callback outcomes
   expect_error(
     markov.misc:::inferences_bootstrap(
       structure(data.frame(), class = "markov_sops"),
+      engine = "standard",
       n_boot = 1,
       workers = NULL,
       conf_level = 0.95,
@@ -441,6 +489,7 @@ test_that("inferences_bootstrap() validates inputs and records callback outcomes
   expect_error(
     markov.misc:::inferences_bootstrap(
       no_data,
+      engine = "standard",
       n_boot = 1,
       workers = NULL,
       conf_level = 0.95,
@@ -457,6 +506,7 @@ test_that("inferences_bootstrap() validates inputs and records callback outcomes
   expect_error(
     markov.misc:::inferences_bootstrap(
       missing_id,
+      engine = "standard",
       n_boot = 1,
       workers = NULL,
       conf_level = 0.95,
@@ -473,6 +523,7 @@ test_that("inferences_bootstrap() validates inputs and records callback outcomes
   expect_error(
     markov.misc:::inferences_bootstrap(
       baseline_only,
+      engine = "standard",
       n_boot = 1,
       workers = NULL,
       conf_level = 0.95,
@@ -529,6 +580,7 @@ test_that("inferences_bootstrap() validates inputs and records callback outcomes
       expect_warning(
         out <- markov.misc:::inferences_bootstrap(
           object,
+          engine = "standard",
           n_boot = 3,
           workers = NULL,
           conf_level = 0.8,
@@ -555,6 +607,7 @@ test_that("inferences_bootstrap() validates inputs and records callback outcomes
       expect_error(
         markov.misc:::inferences_bootstrap(
           object,
+          engine = "standard",
           n_boot = 1,
           workers = NULL,
           conf_level = 0.95,
@@ -567,4 +620,77 @@ test_that("inferences_bootstrap() validates inputs and records callback outcomes
       )
     }
   )
+})
+
+test_that("inferences_bootstrap() supports fractional weighted refits", {
+  model <- structure(list(coefficients = c(a = 0)), class = "mock_model")
+  newdata <- data.frame(
+    id = rep(1:2, each = 2),
+    time = rep(1:2, times = 2),
+    y = factor(c(1, 2, 1, 2), levels = 1:2),
+    yprev = factor(c(1, 1, 1, 1), levels = 1:2),
+    tx = c(0, 0, 1, 1)
+  )
+  object <- make_avg_sops_object(model, newdata)
+
+  fit_weights_seen <- NULL
+  with_mocked_bindings(
+    generate_fwb_bootstrap_weights = function(data, id_var, n_boot) {
+      list(data.frame(
+        original_id = c(1, 2),
+        fwb_weight = c(0.5, 1.5),
+        boot_id = 1
+      ))
+    },
+    bootstrap_analysis_wrapper = function(
+      boot_data,
+      model,
+      factor_cols,
+      original_data,
+      ylevels,
+      absorb,
+      update_datadist,
+      use_coefstart,
+      fit_weights
+    ) {
+      fit_weights_seen <<- fit_weights
+      list(
+        model = model,
+        data = boot_data,
+        ylevels = 1:2,
+        absorb = NULL,
+        missing_states = character(0)
+      )
+    },
+    soprob_markov = function(...) {
+      array(
+        c(
+          0.8, 0.7, 0.2, 0.3,
+          0.6, 0.5, 0.4, 0.5,
+          0.7, 0.6, 0.3, 0.4,
+          0.5, 0.4, 0.5, 0.6
+        ),
+        dim = c(4, 2, 2)
+      )
+    },
+    {
+      out <- markov.misc:::inferences_bootstrap(
+        object,
+        engine = "fwb",
+        n_boot = 1,
+        workers = NULL,
+        conf_level = 0.95,
+        return_draws = TRUE,
+        update_datadist = FALSE,
+        use_coefstart = FALSE
+      )
+    }
+  )
+
+  expect_equal(fit_weights_seen, c(0.5, 0.5, 1.5, 1.5))
+  expect_equal(attr(out, "method"), "bootstrap")
+  expect_equal(attr(out, "engine"), "fwb")
+  expect_equal(attr(out, "fwb_weight_type"), "exponential")
+  expect_equal(attr(out, "fwb_weight_scale"), "cluster_mean_1")
+  expect_s3_class(attr(out, "bootstrap_draws"), "data.frame")
 })

--- a/tests/testthat/test-sops-inferences.R
+++ b/tests/testthat/test-sops-inferences.R
@@ -105,9 +105,11 @@ describe("avg_sops() and inferences() pipeline", {
   }
 
   pipeline_signature <- function(result) {
-    keep <- result$time %in% c(1, 3, 5, 8) &
-      result$state %in% c(1, 3, 6)
-    out <- result[keep, c("tx", "time", "state", "estimate", "conf.low", "conf.high", "std.error")]
+    keep <- result$time %in% c(1, 3, 5, 8) & result$state %in% c(1, 3, 6)
+    out <- result[
+      keep,
+      c("tx", "time", "state", "estimate", "conf.low", "conf.high", "std.error")
+    ]
     out <- out[order(out$tx, out$time, out$state), , drop = FALSE]
     out$state <- as.integer(as.character(out$state))
     numeric_cols <- c("estimate", "conf.low", "conf.high", "std.error")
@@ -117,7 +119,8 @@ describe("avg_sops() and inferences() pipeline", {
   }
 
   draw_signature <- function(draws) {
-    keep <- draws$draw_id %in% c(1L, 2L) &
+    keep <- draws$draw_id %in%
+      c(1L, 2L) &
       draws$time %in% c(1, 4, 8) &
       draws$state %in% c(1, 6)
     out <- draws[keep, c("draw_id", "tx", "time", "state", "draw")]
@@ -149,7 +152,10 @@ describe("avg_sops() and inferences() pipeline", {
     for (i in seq_len(nrow(grid))) {
       rows <- ((i - 1) * nrow(baseline) + 1):(i * nrow(baseline))
       expect_equal(out$tx[rows], rep(grid$tx[i], nrow(baseline)))
-      expect_equal(as.character(out$sex[rows]), rep(as.character(grid$sex[i]), nrow(baseline)))
+      expect_equal(
+        as.character(out$sex[rows]),
+        rep(as.character(grid$sex[i]), nrow(baseline))
+      )
     }
   })
 
@@ -182,10 +188,18 @@ describe("avg_sops() and inferences() pipeline", {
   test_that("marginalize_sops_array() supports patient weights", {
     sops_array <- array(
       c(
-        0.1, 0.7, 0.2,
-        0.2, 0.6, 0.2,
-        0.3, 0.4, 0.3,
-        0.4, 0.3, 0.3
+        0.1,
+        0.7,
+        0.2,
+        0.2,
+        0.6,
+        0.2,
+        0.3,
+        0.4,
+        0.3,
+        0.4,
+        0.3,
+        0.3
       ),
       dim = c(2, 2, 3)
     )
@@ -253,7 +267,9 @@ describe("avg_sops() and inferences() pipeline", {
       data = out,
       FUN = mean
     )
-    stratified <- stratified[order(stratified$time, stratified$state, stratified$tx), ]
+    stratified <- stratified[
+      order(stratified$time, stratified$state, stratified$tx),
+    ]
     manual <- manual[order(manual$time, manual$state, manual$tx), ]
     rownames(stratified) <- NULL
     rownames(manual) <- NULL
@@ -284,7 +300,10 @@ describe("avg_sops() and inferences() pipeline", {
 
     expect_equal(perc$conf.low, c(0.175, 0.575))
     expect_equal(perc$conf.high, c(0.425, 0.825))
-    expect_equal(perc$std.error, c(stats::sd(draws$estimate[1:4]), stats::sd(draws$estimate[5:8])))
+    expect_equal(
+      perc$std.error,
+      c(stats::sd(draws$estimate[1:4]), stats::sd(draws$estimate[5:8]))
+    )
 
     critical <- abs(stats::qnorm(0.25))
     expected_wald_low <- c(
@@ -299,7 +318,11 @@ describe("avg_sops() and inferences() pipeline", {
     expect_equal(wald$conf.low, expected_wald_low)
     expect_equal(wald$conf.high, expected_wald_high)
     expect_error(
-      markov.misc:::compute_ci_from_draws(draws, c("time", "state"), conf_type = "other"),
+      markov.misc:::compute_ci_from_draws(
+        draws,
+        c("time", "state"),
+        conf_type = "other"
+      ),
       "conf_type"
     )
   })
@@ -307,8 +330,12 @@ describe("avg_sops() and inferences() pipeline", {
   test_that("lp_to_probs() converts cumulative logits into valid category probabilities", {
     eta <- matrix(
       c(
-        -1, 0, 1,
-        0.5, -0.5, -1
+        -1,
+        0,
+        1,
+        0.5,
+        -0.5,
+        -1
       ),
       nrow = 2,
       byrow = TRUE
@@ -368,7 +395,11 @@ describe("avg_sops() and inferences() pipeline", {
 
     expect_equal(dim(fast), dim(slow))
     expect_equal(unname(fast), unname(slow), tolerance = 1e-10)
-    expect_equal(rowSums(fast[, 8, , drop = FALSE][, 1, ]), rep(1, nrow(baseline)), tolerance = 1e-10)
+    expect_equal(
+      rowSums(fast[, 8, , drop = FALSE][, 1, ]),
+      rep(1, nrow(baseline)),
+      tolerance = 1e-10
+    )
   })
 
   test_that("fast Markov components support inline rcs() time terms", {
@@ -531,7 +562,7 @@ describe("avg_sops() and inferences() pipeline", {
     expect_equal(sort(unique(draws$draw_id)), 1:2)
   })
 
-  test_that("Brownian avg_sops() supports bootstrap inference", {
+  test_that("avg_sops() supports standard bootstrap inference", {
     skip_if_not_installed("VGAM")
     skip_if_not_installed("rms")
 
@@ -578,6 +609,47 @@ describe("avg_sops() and inferences() pipeline", {
     )
   })
 
+  test_that("avg_sops() supports fractional weighted bootstrap inference", {
+    skip_if_not_installed("VGAM")
+    skip_if_not_installed("rms")
+
+    case <- build_brownian_pipeline_case()
+    model <- fit_pipeline_model(case$data)
+
+    avg <- markov.misc::avg_sops(
+      model = model,
+      newdata = case$data,
+      variables = "tx",
+      times = 1:8,
+      ylevels = case$ylevels,
+      absorb = case$absorb,
+      tvarname = "time_lin",
+      pvarname = "yprev",
+      t_covs = case$t_covs,
+      id_var = "id"
+    )
+
+    withr::local_seed(4404)
+    inferred <- markov.misc::inferences(
+      avg,
+      method = "bootstrap",
+      engine = "fwb",
+      n_sim = 2,
+      return_draws = TRUE
+    )
+
+    draws <- markov.misc::get_draws(inferred)
+
+    expect_equal(attr(inferred, "method"), "bootstrap")
+    expect_equal(attr(inferred, "engine"), "fwb")
+    expect_equal(attr(inferred, "fwb_weight_type"), "exponential")
+    expect_equal(attr(inferred, "fwb_weight_scale"), "cluster_mean_1")
+    expect_equal(attr(inferred, "n_boot"), 2)
+    expect_equal(attr(inferred, "n_successful"), 2L)
+    expect_inference_intervals(inferred)
+    expect_equal(sort(unique(draws$draw_id)), 1:2)
+  })
+
   test_that("numeric previous-state spline supports bootstrap inference", {
     skip_if_not_installed("VGAM")
     skip_if_not_installed("rms")
@@ -609,7 +681,7 @@ describe("avg_sops() and inferences() pipeline", {
     expect_inference_intervals(inferred)
   })
 
-  test_that("Brownian avg_sops() supports score-bootstrap simulation on the fast path", {
+  test_that("avg_sops() supports score-bootstrap simulation on the fast path", {
     skip_if_not_installed("VGAM")
     skip_if_not_installed("rms")
 
@@ -745,9 +817,21 @@ describe("avg_sops() and inferences() pipeline", {
     explicit_draws <- markov.misc::get_draws(explicit_inferred)
     inline_draws <- markov.misc::get_draws(inline_inferred)
 
-    expect_equal(inline_inferred$estimate, explicit_inferred$estimate, tolerance = 1e-10)
-    expect_equal(inline_inferred$conf.low, explicit_inferred$conf.low, tolerance = 1e-10)
-    expect_equal(inline_inferred$conf.high, explicit_inferred$conf.high, tolerance = 1e-10)
+    expect_equal(
+      inline_inferred$estimate,
+      explicit_inferred$estimate,
+      tolerance = 1e-10
+    )
+    expect_equal(
+      inline_inferred$conf.low,
+      explicit_inferred$conf.low,
+      tolerance = 1e-10
+    )
+    expect_equal(
+      inline_inferred$conf.high,
+      explicit_inferred$conf.high,
+      tolerance = 1e-10
+    )
     expect_equal(inline_draws$draw, explicit_draws$draw, tolerance = 1e-10)
   })
 
@@ -758,8 +842,14 @@ describe("avg_sops() and inferences() pipeline", {
     case <- build_brownian_pipeline_case()
     explicit_model <- fit_pipeline_model(case$data)
     inline_model <- fit_inline_pipeline_model(case$data)
-    explicit_robust <- markov.misc::robcov_vglm(explicit_model, cluster = case$data$id)
-    inline_robust <- markov.misc::robcov_vglm(inline_model, cluster = case$data$id)
+    explicit_robust <- markov.misc::robcov_vglm(
+      explicit_model,
+      cluster = case$data$id
+    )
+    inline_robust <- markov.misc::robcov_vglm(
+      inline_model,
+      cluster = case$data$id
+    )
 
     explicit_avg <- markov.misc::avg_sops(
       model = explicit_robust,
@@ -806,9 +896,21 @@ describe("avg_sops() and inferences() pipeline", {
     explicit_draws <- markov.misc::get_draws(explicit_inferred)
     inline_draws <- markov.misc::get_draws(inline_inferred)
 
-    expect_equal(inline_inferred$estimate, explicit_inferred$estimate, tolerance = 1e-10)
-    expect_equal(inline_inferred$conf.low, explicit_inferred$conf.low, tolerance = 1e-10)
-    expect_equal(inline_inferred$conf.high, explicit_inferred$conf.high, tolerance = 1e-10)
+    expect_equal(
+      inline_inferred$estimate,
+      explicit_inferred$estimate,
+      tolerance = 1e-10
+    )
+    expect_equal(
+      inline_inferred$conf.low,
+      explicit_inferred$conf.low,
+      tolerance = 1e-10
+    )
+    expect_equal(
+      inline_inferred$conf.high,
+      explicit_inferred$conf.high,
+      tolerance = 1e-10
+    )
     expect_equal(inline_draws$draw, explicit_draws$draw, tolerance = 1e-10)
   })
 
@@ -844,11 +946,18 @@ describe("avg_sops() and inferences() pipeline", {
     )
 
     ordinary_fitted <- stats::predict(ordinary_fit, type = "response")
-    markov_fitted <- markov.misc:::predict_vglm_response_markov(markov_fit, data)
+    markov_fitted <- markov.misc:::predict_vglm_response_markov(
+      markov_fit,
+      data
+    )
 
     expect_s4_class(markov_fit, "vglm")
     expect_true(isTRUE(attr(markov_fit, "markov_vglm")))
-    expect_equal(unname(markov_fitted), unname(ordinary_fitted), tolerance = 1e-10)
+    expect_equal(
+      unname(markov_fitted),
+      unname(ordinary_fitted),
+      tolerance = 1e-10
+    )
   })
 
   test_that("inline rcs vglm.markov() model can use column-level PPO constraints", {
@@ -877,7 +986,11 @@ describe("avg_sops() and inferences() pipeline", {
     )
 
     cons <- fit_po@constraints
-    linear_time_term <- grep("^rms::rcs\\(time, 4\\).*time$", names(cons), value = TRUE)[[1]]
+    linear_time_term <- grep(
+      "^rms::rcs\\(time, 4\\).*time$",
+      names(cons),
+      value = TRUE
+    )[[1]]
     n_thresholds <- nrow(cons[[linear_time_term]])
     yprev_terms <- grep("^yprev", names(cons), value = TRUE)
     cons[yprev_terms] <- NULL
@@ -934,7 +1047,11 @@ describe("avg_sops() and inferences() pipeline", {
     data <- add_patient_age(data)
     data <- add_time_basis(data)
 
-    explicit_basis <- unname(as.matrix(data[, c("time_lin", "time_nlin_1", "time_nlin_2")]))
+    explicit_basis <- unname(as.matrix(data[, c(
+      "time_lin",
+      "time_nlin_1",
+      "time_nlin_2"
+    )]))
     inline_basis_raw <- rms::rcs(data$time, 4)
     inline_basis <- matrix(
       as.numeric(inline_basis_raw),
@@ -981,7 +1098,11 @@ describe("avg_sops() and inferences() pipeline", {
     )
 
     inline_constraints <- inline_po@constraints
-    inline_time_terms <- grep("^rms::rcs\\(time, 4\\)", names(inline_constraints), value = TRUE)
+    inline_time_terms <- grep(
+      "^rms::rcs\\(time, 4\\)",
+      names(inline_constraints),
+      value = TRUE
+    )
     expect_length(inline_time_terms, 3)
     inline_linear_time_term <- inline_time_terms[[1]]
     expect_match(inline_linear_time_term, "time$")
@@ -1004,9 +1125,16 @@ describe("avg_sops() and inferences() pipeline", {
     inline_fit@call$constraints <- inline_constraints
 
     explicit_fitted <- stats::predict(explicit_fit, type = "response")
-    inline_fitted <- markov.misc:::predict_vglm_response_markov(inline_fit, data)
+    inline_fitted <- markov.misc:::predict_vglm_response_markov(
+      inline_fit,
+      data
+    )
     expect_equal(dim(inline_fitted), dim(explicit_fitted))
-    expect_equal(unname(inline_fitted), unname(explicit_fitted), tolerance = 1e-10)
+    expect_equal(
+      unname(inline_fitted),
+      unname(explicit_fitted),
+      tolerance = 1e-10
+    )
 
     explicit_sops <- markov.misc::avg_sops(
       explicit_fit,
@@ -1040,6 +1168,10 @@ describe("avg_sops() and inferences() pipeline", {
     expect_equal(inline_sops$tx, explicit_sops$tx)
     expect_equal(inline_sops$time, explicit_sops$time)
     expect_equal(inline_sops$state, explicit_sops$state)
-    expect_equal(inline_sops$estimate, explicit_sops$estimate, tolerance = 1e-10)
+    expect_equal(
+      inline_sops$estimate,
+      explicit_sops$estimate,
+      tolerance = 1e-10
+    )
   })
 })

--- a/vignettes/fractional-weighted-bootstrap-sops.Rmd
+++ b/vignettes/fractional-weighted-bootstrap-sops.Rmd
@@ -1,0 +1,162 @@
+---
+title: "Fractional Weighted Bootstrap for SOPs"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Fractional Weighted Bootstrap for SOPs}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 7,
+  fig.height = 4.8,
+  out.width = "100%",
+  message = FALSE,
+  warning = FALSE
+)
+```
+
+This vignette shows the fractional weighted bootstrap (FWB) engine for marginal
+state occupancy probabilities.
+
+The ordinary refit bootstrap samples patients with replacement, refits the
+transition model, and recomputes SOPs. The FWB keeps every patient in every
+bootstrap replicate, draws one positive exponential weight per patient, refits
+the model with those row-expanded weights, and uses the same patient weights
+when marginalizing SOPs. This can be useful when ordinary bootstrap resamples
+occasionally create sparse or degenerate refit samples.
+
+The number of bootstrap replicates is deliberately tiny for vignette runtime.
+
+## Fit The Model
+
+```{r setup}
+library(markov.misc)
+library(ggplot2)
+library(rms)
+
+N_PATIENTS <- 160
+FOLLOW_UP <- 10
+N_BOOT <- 30
+SEED <- 20260606
+STATE_LEVELS <- as.character(1:8)
+ABSORB <- "8"
+
+raw_data <- sim_actt2_brownian(
+  n_patients = N_PATIENTS,
+  follow_up_time = FOLLOW_UP,
+  mu_treatment_effect = -0.03,
+  seed = SEED
+)
+
+model_data <- prepare_markov_data(
+  raw_data,
+  absorbing_state = as.integer(ABSORB),
+  factor_previous = TRUE
+)
+
+fit <- orm(
+  y ~ tx + rcs(time, 4) + yprev,
+  data = model_data,
+  x = TRUE,
+  y = TRUE,
+  opt_method = "LM",
+  scale = TRUE,
+  maxit = 100
+)
+
+c(
+  patients = length(unique(model_data$id)),
+  transitions = nrow(model_data),
+  states = length(STATE_LEVELS)
+)
+```
+
+## Define Marginal SOPs
+
+Refit bootstrap inference needs the full longitudinal transition data in
+`newdata`, not just one baseline row per patient, because each bootstrap draw
+refits the transition model.
+
+```{r avg-sops}
+avg <- avg_sops(
+  fit,
+  newdata = model_data,
+  variables = list(tx = c(0, 1)),
+  times = seq_len(FOLLOW_UP),
+  ylevels = fit$yunique,
+  absorb = ABSORB,
+  id_var = "id"
+)
+
+head(avg)
+```
+
+## Run Standard And Fractional Bootstrap
+
+Use `engine = "standard"` for ordinary patient resampling and `engine = "fwb"`
+for fractional weighted refits. The default bootstrap engine is standard, so
+the first call could omit `engine`.
+
+```{r run-bootstrap}
+set.seed(SEED)
+sop_standard <- inferences(
+  avg,
+  method = "bootstrap",
+  engine = "standard",
+  n_sim = N_BOOT,
+  workers = 1,
+  return_draws = TRUE
+)
+
+set.seed(SEED)
+sop_fwb <- inferences(
+  avg,
+  method = "bootstrap",
+  engine = "fwb",
+  n_sim = N_BOOT,
+  workers = 1,
+  return_draws = TRUE
+)
+
+data.frame(
+  engine = c(attr(sop_standard, "engine"), attr(sop_fwb, "engine")),
+  successful_draws = c(
+    attr(sop_standard, "n_successful"),
+    attr(sop_fwb, "n_successful")
+  ),
+  weight_type = c(NA, attr(sop_fwb, "fwb_weight_type")),
+  weight_scale = c(NA, attr(sop_fwb, "fwb_weight_scale"))
+)
+```
+
+## Compare
+
+The point estimates are the same because both inference calls start from the
+same fitted model and marginal SOP target. The interval estimates differ
+because the bootstrap draws are generated differently.
+
+```{r compare}
+comparison <- rbind(
+  data.frame(engine = "Standard bootstrap", as.data.frame(sop_standard)),
+  data.frame(engine = "Fractional weighted bootstrap", as.data.frame(sop_fwb))
+)
+
+plot_sops(
+  comparison,
+  geom = "line",
+  facet_var = c("engine", "tx")
+) +
+  labs(
+    x = "Day",
+    y = "State occupancy probability"
+  )
+```
+
+The FWB metadata records the implemented weighting scheme: exponential
+patient-level weights normalized to mean 1 for model fitting. The marginal SOP
+averaging step normalizes the same patient weights to sum 1 within each
+bootstrap replicate.


### PR DESCRIPTION
## Summary
Adds fractional weighted bootstrap (FWB) support for SOP inference via `inferences(..., method = "bootstrap", engine = "fwb")`. The implementation draws patient-level exponential weights, normalizes them to mean 1 for weighted model refits, expands them to longitudinal rows, and passes baseline patient weights through the existing SOP marginalization helper.

This also keeps standard bootstrap as the default bootstrap engine, preserves the legacy `engine = "mvn"` bootstrap behavior as standard bootstrap, validates unsupported method/engine combinations, and records FWB metadata on results.

The branch also includes the prior threshold-specific Brownian simulator update already present before the FWB commit.

## Documentation
Updates roxygen-generated docs, `NEWS.md`, `ARCHITECTURE.md`, and adds `vignettes/fractional-weighted-bootstrap-sops.Rmd`.

## Verification
- `Rscript -e "devtools::document()"`
- `Rscript -e "devtools::test(filter = 'bootstrap_helpers|sops-inference-errors|sops-inferences')"` passed with 231 tests, 0 failures, 0 warnings.